### PR TITLE
Виправити зависання при невдалій авторизації через Google

### DIFF
--- a/lib/src/cubit/auth/auth_cubit.dart
+++ b/lib/src/cubit/auth/auth_cubit.dart
@@ -8,9 +8,11 @@ part 'auth_state.dart';
 
 class AuthCubit extends Cubit<AuthState> {
   late final StreamSubscription<supabase_auth.AuthState> _authStateSubscription;
+  Timer? _oauthTimer;
 
   AuthCubit() : super(_initialState()) {
     _authStateSubscription = supabase.auth.onAuthStateChange.listen((data) {
+      _oauthTimer?.cancel();
       final user = data.session?.user;
 
       if (user != null) {
@@ -83,9 +85,21 @@ class AuthCubit extends Cubit<AuthState> {
   Future<void> signInWithGoogle() async {
     emit(AuthLoading());
     try {
-      await supabase.auth.signInWithOAuth(
+      final launched = await supabase.auth.signInWithOAuth(
         supabase_auth.OAuthProvider.google,
       );
+      if (!launched) {
+        emit(AuthError('Не вдалося відкрити вікно авторизації Google.'));
+        return;
+      }
+      // Browser opened. Actual auth result arrives via onAuthStateChange.
+      // Reset to unauthenticated if user cancels or deep link never fires.
+      _oauthTimer?.cancel();
+      _oauthTimer = Timer(const Duration(seconds: 60), () {
+        if (state is AuthLoading) {
+          emit(AuthUnauthenticated());
+        }
+      });
     } on supabase_auth.AuthException catch (error) {
       emit(AuthError(_mapAuthException(error)));
     } catch (_) {
@@ -122,6 +136,7 @@ class AuthCubit extends Cubit<AuthState> {
 
   @override
   Future<void> close() async {
+    _oauthTimer?.cancel();
     await _authStateSubscription.cancel();
     return super.close();
   }

--- a/lib/src/screens/auth_page/login_form.dart
+++ b/lib/src/screens/auth_page/login_form.dart
@@ -127,18 +127,26 @@ class LoginForm extends StatelessWidget {
               return const SizedBox.shrink();
             },
           ),
-          ElevatedButton.icon(
-            onPressed: () => _onGoogleLogin(context),
-            icon: const Icon(Icons.g_mobiledata),
-            label: const Text('Увійти через Google'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.white,
-              foregroundColor: Colors.black,
-              padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 24),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-            ),
+          BlocBuilder<AuthCubit, AuthState>(
+            builder: (context, state) {
+              final isLoading = state is AuthLoading;
+              return ElevatedButton.icon(
+                onPressed: isLoading ? null : () => _onGoogleLogin(context),
+                icon: const Icon(Icons.g_mobiledata),
+                label: const Text('Увійти через Google'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.white,
+                  foregroundColor: Colors.black,
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 14,
+                    horizontal: 24,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              );
+            },
           ),
           const SizedBox(height: 16),
           TextButton(


### PR DESCRIPTION
Якщо OAuth не завершується (скасування, відсутній deep link), додати таймаут 60с після якого стан скидається в AuthUnauthenticated. Перевіряти повернення signInWithOAuth і блокувати кнопку Google під час завантаження.