### PR TITLE
ci: update Flutter version from 3.24.5 to 3.32.7

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  FLUTTER_VERSION: '3.24.5'
+  FLUTTER_VERSION: '3.32.7'
 
 jobs:
   analyze:


### PR DESCRIPTION
Color.withValues(alpha:) requires Flutter 3.27+.
Align CI with the version used in development.