### PR TITLE
feat: apply black-orange theme across entire app

### DIFF
--- a/lib/core/app_colors.dart
+++ b/lib/core/app_colors.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+abstract final class AppColors {
+  static const bgDeep     = Color(0xFF0C0C0C);
+  static const bgSurface  = Color(0xFF161616);
+  static const bgElevated = Color(0xFF1F1F1F);
+  static const border     = Color(0xFF2C2C2C);
+
+  static const orange     = Color(0xFFFF6B00);
+  static const orangeWarm = Color(0xFFFF9240);
+  static const amber      = Color(0xFFFFC84A);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/core/auth_guard.dart';
 import 'package:test1/firebase_options.dart';
 import 'package:test1/src/bloc/connection/connection_bloc.dart';
@@ -69,30 +70,6 @@ void main() async {
   );
 }
 
-class _StubPage extends StatelessWidget {
-  final String title;
-
-  const _StubPage({required this.title});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFF1A1B2D),
-      appBar: AppBar(
-        backgroundColor: const Color(0xFF1A1B2D),
-        foregroundColor: Colors.white,
-        title: Text(title),
-      ),
-      body: const Center(
-        child: Text(
-          'В розробці',
-          style: TextStyle(color: Colors.white54, fontSize: 18),
-        ),
-      ),
-    );
-  }
-}
-
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
@@ -102,13 +79,23 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: 'Чіпідізєль',
       theme: ThemeData(
-        primarySwatch: Colors.teal,
+        brightness: Brightness.dark,
+        scaffoldBackgroundColor: AppColors.bgDeep,
+        colorScheme: const ColorScheme.dark(
+          primary: AppColors.orange,
+          surface: AppColors.bgSurface,
+        ),
         elevatedButtonTheme: ElevatedButtonThemeData(
           style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.orange,
+            foregroundColor: Colors.white,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(30),
             ),
-            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 32,
+              vertical: 16,
+            ),
             textStyle: const TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,
@@ -116,11 +103,25 @@ class MyApp extends StatelessWidget {
           ),
         ),
         inputDecorationTheme: InputDecorationTheme(
+          filled: true,
+          fillColor: AppColors.bgElevated,
+          labelStyle: const TextStyle(color: Colors.white54),
+          hintStyle: const TextStyle(color: Colors.white30),
           border: OutlineInputBorder(
             borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: AppColors.border),
           ),
-          filled: true,
-          fillColor: Colors.white,
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: AppColors.border),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(
+              color: AppColors.orange,
+              width: 2,
+            ),
+          ),
         ),
       ),
       initialRoute: '/',

--- a/lib/presentation/widgets/backend_status_widget.dart
+++ b/lib/presentation/widgets/backend_status_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:test1/core/app_colors.dart';
 
 class BackendStatusWidget extends StatefulWidget {
   final DateTime? lastUpdated;
@@ -35,7 +36,7 @@ class _BackendStatusWidgetState extends State<BackendStatusWidget> {
     if (last == null) {
       return const _StatusChip(
         text: 'Очікування даних від симулятора...',
-        color: Colors.orange,
+        color: AppColors.amber,
         isWarning: true,
       );
     }
@@ -45,14 +46,14 @@ class _BackendStatusWidgetState extends State<BackendStatusWidget> {
     if (age.inSeconds > 30) {
       return _StatusChip(
         text: 'Немає даних від симулятора (${age.inSeconds} с тому)',
-        color: Colors.orange,
+        color: AppColors.amber,
         isWarning: true,
       );
     }
 
     return _StatusChip(
       text: 'Онлайн, оновлено ${age.inSeconds} с тому',
-      color: Colors.greenAccent,
+      color: AppColors.orangeWarm,
       isWarning: false,
     );
   }
@@ -74,7 +75,7 @@ class _StatusChip extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
       decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
+        color: color.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(20),
         border: Border.all(color: color.withValues(alpha: 0.4)),
       ),

--- a/lib/presentation/widgets/sensor_card.dart
+++ b/lib/presentation/widgets/sensor_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/presentation/cubits/dashboard_cubit.dart';
 
 class SensorCard extends StatelessWidget {
@@ -21,11 +22,11 @@ class SensorCard extends StatelessWidget {
     final value = data.value;
 
     final bgColor = exceeded
-        ? Colors.red.withValues(alpha: 0.22)
-        : Colors.green.withValues(alpha: 0.15);
+        ? Colors.red.withValues(alpha: 0.18)
+        : AppColors.orange.withValues(alpha: 0.08);
     final borderColor = exceeded
-        ? Colors.redAccent.withValues(alpha: 0.6)
-        : Colors.greenAccent.withValues(alpha: 0.4);
+        ? Colors.redAccent.withValues(alpha: 0.55)
+        : AppColors.orange.withValues(alpha: 0.35);
     final valueColor = exceeded ? Colors.redAccent : Colors.white;
 
     return Container(
@@ -40,7 +41,7 @@ class SensorCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(icon, color: Colors.white60, size: 18),
+              Icon(icon, color: AppColors.orangeWarm, size: 18),
               const SizedBox(width: 6),
               Expanded(
                 child: Text(
@@ -83,7 +84,10 @@ class SensorCard extends StatelessWidget {
                 : Text(
                     '— $unit',
                     key: const ValueKey('empty'),
-                    style: const TextStyle(color: Colors.white30, fontSize: 24),
+                    style: const TextStyle(
+                      color: Colors.white24,
+                      fontSize: 24,
+                    ),
                   ),
           ),
         ],

--- a/lib/src/screens/auth_page/login_form.dart
+++ b/lib/src/screens/auth_page/login_form.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/src/cubit/auth/auth_cubit.dart';
 // ignore: unused_import
 import 'package:test1/src/widgets/reusable/reusable_text.dart';
@@ -22,8 +23,6 @@ class LoginForm extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const accentPurple = Color(0xFF8A2BE2);
-
     return BlocListener<AuthCubit, AuthState>(
       listener: (context, state) {
         if (state is AuthAuthenticated) {
@@ -42,35 +41,35 @@ class LoginForm extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const Text(
-            'Ласкаво просимо назад',
+            'Ласкаво просимо',
             style: TextStyle(
               color: Colors.white,
               fontSize: 32,
               fontWeight: FontWeight.bold,
             ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: 6),
           const Text(
             'Увійдіть у свій обліковий запис',
-            style: TextStyle(
-              color: Colors.grey,
-              fontSize: 16,
-            ),
+            style: TextStyle(color: Colors.white54, fontSize: 15),
           ),
-          const SizedBox(height: 32),
+          const SizedBox(height: 36),
           Container(
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(16),
+              color: AppColors.bgSurface,
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(
+                color: AppColors.orange.withValues(alpha: 0.25),
+              ),
             ),
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(20),
             child: Column(
               children: [
                 ReusableTextField(
                   hint: 'Email',
                   controller: _emailController,
                 ),
-                const SizedBox(height: 16),
+                const SizedBox(height: 12),
                 ReusableTextField(
                   hint: 'Пароль',
                   obscure: true,
@@ -83,25 +82,32 @@ class LoginForm extends StatelessWidget {
           BlocBuilder<AuthCubit, AuthState>(
             builder: (context, state) {
               final isLoading = state is AuthLoading;
-
               return SizedBox(
                 width: double.infinity,
+                height: 52,
                 child: ElevatedButton(
                   onPressed: isLoading ? null : () => _onLogin(context),
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: accentPurple,
-                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    backgroundColor: AppColors.orange,
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
+                      borderRadius: BorderRadius.circular(14),
                     ),
+                    padding: EdgeInsets.zero,
                   ),
                   child: isLoading
-                      ? const CircularProgressIndicator(color: Colors.white)
+                      ? const SizedBox(
+                          height: 22,
+                          width: 22,
+                          child: CircularProgressIndicator(
+                            color: Colors.white,
+                            strokeWidth: 2.5,
+                          ),
+                        )
                       : const Text(
                           'Увійти',
                           style: TextStyle(
                             color: Colors.white,
-                            fontSize: 18,
+                            fontSize: 17,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
@@ -109,70 +115,71 @@ class LoginForm extends StatelessWidget {
               );
             },
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
           BlocBuilder<AuthCubit, AuthState>(
             builder: (context, state) {
               if (state is AuthError) {
-                return Column(
-                  children: [
-                    Text(
-                      state.message,
-                      style: const TextStyle(color: Colors.red),
-                    ),
-                    const SizedBox(height: 16),
-                  ],
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Text(
+                    state.message,
+                    style: const TextStyle(color: Colors.redAccent),
+                    textAlign: TextAlign.center,
+                  ),
                 );
               }
               return const SizedBox.shrink();
             },
           ),
+          const Row(
+            children: [
+              Expanded(
+                child: Divider(color: Colors.white12, thickness: 1),
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Text('або', style: TextStyle(color: Colors.white38)),
+              ),
+              Expanded(
+                child: Divider(color: Colors.white12, thickness: 1),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
           BlocBuilder<AuthCubit, AuthState>(
             builder: (context, state) {
               final isLoading = state is AuthLoading;
-              return ElevatedButton.icon(
-                onPressed: isLoading ? null : () => _onGoogleLogin(context),
-                icon: const Icon(Icons.g_mobiledata),
-                label: const Text('Увійти через Google'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.white,
-                  foregroundColor: Colors.black,
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 14,
-                    horizontal: 24,
+              return SizedBox(
+                width: double.infinity,
+                height: 50,
+                child: OutlinedButton.icon(
+                  onPressed:
+                      isLoading ? null : () => _onGoogleLogin(context),
+                  icon: const Icon(
+                    Icons.g_mobiledata,
+                    color: Colors.white70,
                   ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
+                  label: const Text(
+                    'Увійти через Google',
+                    style: TextStyle(color: Colors.white70, fontSize: 15),
+                  ),
+                  style: OutlinedButton.styleFrom(
+                    side: const BorderSide(color: AppColors.border, width: 1.5),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
                   ),
                 ),
               );
             },
           ),
-          const SizedBox(height: 16),
-          TextButton(
-            onPressed: () {},
-            child: const Text(
-              'Забули пароль?',
-              style: TextStyle(color: Colors.white70),
-            ),
-          ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Container(width: 60, height: 1, color: Colors.white30),
-              const SizedBox(width: 8),
-              const Text('або', style: TextStyle(color: Colors.white54)),
-              const SizedBox(width: 8),
-              Container(width: 60, height: 1, color: Colors.white30),
-            ],
-          ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 20),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               const Text(
                 'Немає облікового запису? ',
-                style: TextStyle(color: Colors.white70),
+                style: TextStyle(color: Colors.white54),
               ),
               GestureDetector(
                 onTap: () {
@@ -189,15 +196,14 @@ class LoginForm extends StatelessWidget {
                 child: const Text(
                   'Зареєструватися',
                   style: TextStyle(
-                    color: Colors.white,
+                    color: AppColors.orangeWarm,
                     fontWeight: FontWeight.bold,
-                    decoration: TextDecoration.underline,
                   ),
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 8),
         ],
       ),
     );

--- a/lib/src/screens/auth_page/login_page.dart
+++ b/lib/src/screens/auth_page/login_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:test1/core/app_colors.dart';
 // ignore: unused_import
 import 'package:test1/src/screens/auth_page/login_form.dart';
 import 'package:test1/src/screens/auth_page/login_listeners.dart';
@@ -8,11 +9,9 @@ class LoginPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const darkBackground = Color(0xFF1A1B2D);
-
     return LoginListeners(
       child: Scaffold(
-        backgroundColor: darkBackground,
+        backgroundColor: AppColors.bgDeep,
         body: Stack(
           children: [
             const _LoginBackground(),
@@ -41,14 +40,10 @@ class _LoginBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const darkBackground = Color(0xFF1A1B2D);
-    const accentPurple = Color(0xFF8A2BE2);
-    const lightPurple = Color(0xFFB19CD9);
-
     return DecoratedBox(
       decoration: const BoxDecoration(
         gradient: LinearGradient(
-          colors: [darkBackground, Color(0xFF25274D)],
+          colors: [AppColors.bgDeep, Color(0xFF1A0A00)],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
@@ -56,19 +51,37 @@ class _LoginBackground extends StatelessWidget {
       child: Stack(
         children: [
           Positioned(
-            top: -100,
-            left: -50,
-            child: CircleAvatar(
-              radius: 100,
-              backgroundColor: lightPurple.withValues(alpha: 0.3),
+            top: -80,
+            right: -40,
+            child: Container(
+              width: 240,
+              height: 240,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: RadialGradient(
+                  colors: [
+                    AppColors.orange.withValues(alpha: 0.35),
+                    AppColors.orange.withValues(alpha: 0),
+                  ],
+                ),
+              ),
             ),
           ),
           Positioned(
-            bottom: -120,
-            right: -50,
-            child: CircleAvatar(
-              radius: 125,
-              backgroundColor: accentPurple.withValues(alpha: 0.2),
+            bottom: -80,
+            left: -40,
+            child: Container(
+              width: 200,
+              height: 200,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: RadialGradient(
+                  colors: [
+                    AppColors.orangeWarm.withValues(alpha: 0.25),
+                    AppColors.orangeWarm.withValues(alpha: 0),
+                  ],
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/src/screens/auth_page/register_form.dart
+++ b/lib/src/screens/auth_page/register_form.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/src/cubit/auth/auth_cubit.dart';
 // ignore: unused_import
 import 'package:test1/src/widgets/reusable/reusable_text.dart';
@@ -36,8 +37,6 @@ class _RegisterFormState extends State<RegisterForm> {
 
   @override
   Widget build(BuildContext context) {
-    const accentPurple = Color(0xFF8A2BE2);
-
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -49,36 +48,33 @@ class _RegisterFormState extends State<RegisterForm> {
             fontWeight: FontWeight.bold,
           ),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 6),
         const Text(
           'Створіть новий обліковий запис',
-          style: TextStyle(color: Colors.grey, fontSize: 16),
+          style: TextStyle(color: Colors.white54, fontSize: 15),
         ),
-        const SizedBox(height: 32),
+        const SizedBox(height: 36),
         Container(
           decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.1),
-            borderRadius: BorderRadius.circular(16),
+            color: AppColors.bgSurface,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: AppColors.orange.withValues(alpha: 0.25),
+            ),
           ),
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(20),
           child: Column(
             children: [
-              ReusableTextField(
-                hint: 'Email',
-                controller: _emailController,
-              ),
-              const SizedBox(height: 16),
-              ReusableTextField(
-                hint: 'Ім’я',
-                controller: _nameController,
-              ),
-              const SizedBox(height: 16),
+              ReusableTextField(hint: 'Email', controller: _emailController),
+              const SizedBox(height: 12),
+              ReusableTextField(hint: "Ім'я", controller: _nameController),
+              const SizedBox(height: 12),
               ReusableTextField(
                 hint: 'Пароль',
                 obscure: true,
                 controller: _passwordController,
               ),
-              const SizedBox(height: 16),
+              const SizedBox(height: 12),
               ReusableTextField(
                 hint: 'Підтвердіть пароль',
                 obscure: true,
@@ -91,14 +87,13 @@ class _RegisterFormState extends State<RegisterForm> {
         BlocBuilder<AuthCubit, AuthState>(
           builder: (context, state) {
             if (state is AuthError) {
-              return Column(
-                children: [
-                  Text(
-                    state.message,
-                    style: const TextStyle(color: Colors.red),
-                  ),
-                  const SizedBox(height: 16),
-                ],
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Text(
+                  state.message,
+                  style: const TextStyle(color: Colors.redAccent),
+                  textAlign: TextAlign.center,
+                ),
               );
             }
             return const SizedBox.shrink();
@@ -109,22 +104,30 @@ class _RegisterFormState extends State<RegisterForm> {
             final isLoading = state is AuthLoading;
             return SizedBox(
               width: double.infinity,
+              height: 52,
               child: ElevatedButton(
                 onPressed: isLoading ? null : () => _onRegister(context),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: accentPurple,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  backgroundColor: AppColors.orange,
                   shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(14),
                   ),
+                  padding: EdgeInsets.zero,
                 ),
                 child: isLoading
-                    ? const CircularProgressIndicator(color: Colors.white)
+                    ? const SizedBox(
+                        height: 22,
+                        width: 22,
+                        child: CircularProgressIndicator(
+                          color: Colors.white,
+                          strokeWidth: 2.5,
+                        ),
+                      )
                     : const Text(
                         'Зареєструватися',
                         style: TextStyle(
                           color: Colors.white,
-                          fontSize: 18,
+                          fontSize: 17,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
@@ -132,24 +135,21 @@ class _RegisterFormState extends State<RegisterForm> {
             );
           },
         ),
-        const SizedBox(height: 16),
+        const SizedBox(height: 20),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Text(
               'Вже маєте обліковий запис? ',
-              style: TextStyle(color: Colors.white70),
+              style: TextStyle(color: Colors.white54),
             ),
             GestureDetector(
-              onTap: () {
-                Navigator.pop(context);
-              },
+              onTap: () => Navigator.pop(context),
               child: const Text(
                 'Увійдіть',
                 style: TextStyle(
-                  color: Colors.white,
+                  color: AppColors.orangeWarm,
                   fontWeight: FontWeight.bold,
-                  decoration: TextDecoration.underline,
                 ),
               ),
             ),

--- a/lib/src/screens/auth_page/register_page.dart
+++ b/lib/src/screens/auth_page/register_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/src/cubit/auth/auth_cubit.dart';
 // ignore: unused_import
 import 'package:test1/src/screens/auth_page/register_form.dart';
@@ -9,10 +10,6 @@ class RegisterPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const darkBackground = Color(0xFF1A1B2D);
-    const accentPurple = Color(0xFF8A2BE2);
-    const lightPurple = Color(0xFFB19CD9);
-
     return BlocListener<AuthCubit, AuthState>(
       listener: (context, state) {
         if (state is AuthAuthenticated) {
@@ -20,46 +17,57 @@ class RegisterPage extends StatelessWidget {
         }
       },
       child: Scaffold(
-        backgroundColor: darkBackground,
+        backgroundColor: AppColors.bgDeep,
         body: Stack(
           children: [
             Container(
               decoration: const BoxDecoration(
                 gradient: LinearGradient(
-                  colors: [darkBackground, Color(0xFF25274D)],
+                  colors: [AppColors.bgDeep, Color(0xFF1A0A00)],
                   begin: Alignment.topLeft,
                   end: Alignment.bottomRight,
                 ),
               ),
             ),
             Positioned(
-              top: -100,
-              left: -50,
+              top: -80,
+              right: -40,
               child: Container(
-                width: 200,
-                height: 200,
+                width: 240,
+                height: 240,
                 decoration: BoxDecoration(
-                  color: lightPurple.withValues(alpha: 0.3),
                   shape: BoxShape.circle,
+                  gradient: RadialGradient(
+                    colors: [
+                      AppColors.orange.withValues(alpha: 0.35),
+                      AppColors.orange.withValues(alpha: 0),
+                    ],
+                  ),
                 ),
               ),
             ),
             Positioned(
-              bottom: -120,
-              right: -50,
+              bottom: -80,
+              left: -40,
               child: Container(
-                width: 250,
-                height: 250,
+                width: 200,
+                height: 200,
                 decoration: BoxDecoration(
-                  color: accentPurple.withValues(alpha: 0.2),
                   shape: BoxShape.circle,
+                  gradient: RadialGradient(
+                    colors: [
+                      AppColors.orangeWarm.withValues(alpha: 0.25),
+                      AppColors.orangeWarm.withValues(alpha: 0),
+                    ],
+                  ),
                 ),
               ),
             ),
             const SafeArea(
               child: Center(
                 child: SingleChildScrollView(
-                  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                  padding:
+                      EdgeInsets.symmetric(horizontal: 24, vertical: 16),
                   child: RegisterForm(),
                 ),
               ),

--- a/lib/src/screens/events_page/events_page.dart
+++ b/lib/src/screens/events_page/events_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/presentation/cubits/events_cubit.dart';
 
 class EventsPage extends StatefulWidget {
@@ -30,70 +31,74 @@ class _EventsPageState extends State<EventsPage> {
     return BlocProvider<EventsCubit>.value(
       value: _cubit,
       child: Scaffold(
-        backgroundColor: const Color(0xFF1A1B2D),
+        backgroundColor: AppColors.bgDeep,
         appBar: AppBar(
-          backgroundColor: const Color(0xFF1A1B2D),
+          backgroundColor: AppColors.bgSurface,
           foregroundColor: Colors.white,
+          elevation: 0,
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(1),
+            child: Container(
+              height: 1,
+              color: AppColors.orange.withValues(alpha: 0.3),
+            ),
+          ),
           title: const Text('Журнал подій'),
         ),
-        body: Stack(
-          children: [
-            Container(
-              decoration: const BoxDecoration(
-                gradient: LinearGradient(
-                  colors: [Color(0xFF1A1B2D), Color(0xFF25274D)],
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                ),
-              ),
+        body: DecoratedBox(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              colors: [AppColors.bgDeep, Color(0xFF140800)],
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
             ),
-            BlocBuilder<EventsCubit, EventsState>(
-              builder: (context, state) {
-                if (state is EventsLoading) {
+          ),
+          child: BlocBuilder<EventsCubit, EventsState>(
+            builder: (context, state) {
+              if (state is EventsLoading) {
+                return const Center(
+                  child: CircularProgressIndicator(color: AppColors.orange),
+                );
+              }
+              if (state is EventsError) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text(
+                      state.message,
+                      style: const TextStyle(
+                        color: Colors.redAccent,
+                        fontSize: 16,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                );
+              }
+              if (state is EventsLoaded) {
+                if (state.events.isEmpty) {
                   return const Center(
-                    child: CircularProgressIndicator(color: Colors.white),
-                  );
-                }
-                if (state is EventsError) {
-                  return Center(
-                    child: Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Text(
-                        state.message,
-                        style: const TextStyle(
-                          color: Colors.redAccent,
-                          fontSize: 16,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
+                    child: Text(
+                      'Порогів ще не було перевищено',
+                      style: TextStyle(color: Colors.white38, fontSize: 16),
                     ),
                   );
                 }
-                if (state is EventsLoaded) {
-                  if (state.events.isEmpty) {
-                    return const Center(
-                      child: Text(
-                        'Порогів ще не було перевищено',
-                        style: TextStyle(color: Colors.white54, fontSize: 16),
-                      ),
-                    );
-                  }
-                  return RefreshIndicator(
-                    onRefresh: () => context.read<EventsCubit>().refresh(),
-                    color: const Color(0xFF8A2BE2),
-                    backgroundColor: const Color(0xFF25274D),
-                    child: ListView.builder(
-                      padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
-                      itemCount: state.events.length,
-                      itemBuilder: (context, index) =>
-                          _EventCard(event: state.events[index]),
-                    ),
-                  );
-                }
-                return const SizedBox.shrink();
-              },
-            ),
-          ],
+                return RefreshIndicator(
+                  onRefresh: () => context.read<EventsCubit>().refresh(),
+                  color: AppColors.orange,
+                  backgroundColor: AppColors.bgElevated,
+                  child: ListView.builder(
+                    padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
+                    itemCount: state.events.length,
+                    itemBuilder: (context, index) =>
+                        _EventCard(event: state.events[index]),
+                  ),
+                );
+              }
+              return const SizedBox.shrink();
+            },
+          ),
         ),
       ),
     );
@@ -116,13 +121,13 @@ class _EventCard extends StatelessWidget {
         raw != null ? DateTime.parse(raw).toLocal() : DateTime.now();
 
     final isMax = thresholdType == 'max';
-    final accentColor = isMax ? Colors.redAccent : Colors.lightBlueAccent;
+    final accentColor = isMax ? Colors.redAccent : Colors.blueAccent;
     final bgColor = isMax
-        ? Colors.red.withValues(alpha: 0.15)
-        : Colors.blue.withValues(alpha: 0.15);
+        ? Colors.red.withValues(alpha: 0.12)
+        : Colors.blue.withValues(alpha: 0.10);
     final borderColor = isMax
-        ? Colors.redAccent.withValues(alpha: 0.45)
-        : Colors.blueAccent.withValues(alpha: 0.45);
+        ? Colors.redAccent.withValues(alpha: 0.4)
+        : Colors.blueAccent.withValues(alpha: 0.35);
 
     final unit = _unitFor(sensorType);
     final label = _labelFor(sensorType);
@@ -141,7 +146,15 @@ class _EventCard extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(icon, color: Colors.white60, size: 30),
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: accentColor.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(icon, color: accentColor, size: 22),
+          ),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -163,7 +176,10 @@ class _EventCard extends StatelessWidget {
                 const SizedBox(height: 2),
                 Text(
                   thresholdText,
-                  style: const TextStyle(color: Colors.white38, fontSize: 12),
+                  style: const TextStyle(
+                    color: Colors.white38,
+                    fontSize: 12,
+                  ),
                 ),
               ],
             ),

--- a/lib/src/screens/home_page/home_content.dart
+++ b/lib/src/screens/home_page/home_content.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/presentation/cubits/dashboard_cubit.dart';
 import 'package:test1/presentation/widgets/backend_status_widget.dart';
 import 'package:test1/presentation/widgets/sensor_card.dart';
@@ -13,7 +14,7 @@ class HomeContent extends StatelessWidget {
       builder: (context, state) {
         if (state is DashboardLoading) {
           return const Center(
-            child: CircularProgressIndicator(color: Colors.white),
+            child: CircularProgressIndicator(color: AppColors.orange),
           );
         }
 
@@ -56,18 +57,25 @@ class _DashboardView extends StatelessWidget {
         if (state.isFromCache)
           Container(
             width: double.infinity,
-            color: Colors.amber.shade700,
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            decoration: const BoxDecoration(
+              color: AppColors.bgSurface,
+              border: Border(
+                left: BorderSide(color: AppColors.orange, width: 3),
+              ),
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 10,
+            ),
             child: const Row(
               children: [
-                Icon(Icons.wifi_off, color: Colors.black87, size: 18),
-                SizedBox(width: 8),
+                Icon(Icons.wifi_off, color: AppColors.orange, size: 16),
+                SizedBox(width: 10),
                 Expanded(
                   child: Text(
                     'Офлайн — показуємо останні відомі дані',
                     style: TextStyle(
-                      color: Colors.black87,
+                      color: AppColors.orange,
                       fontWeight: FontWeight.w600,
                       fontSize: 13,
                     ),
@@ -78,7 +86,7 @@ class _DashboardView extends StatelessWidget {
           ),
         Expanded(
           child: SingleChildScrollView(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
@@ -87,20 +95,22 @@ class _DashboardView extends StatelessWidget {
                   const SizedBox(height: 10),
                   Container(
                     padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
+                      horizontal: 14,
                       vertical: 10,
                     ),
                     decoration: BoxDecoration(
-                      color: Colors.orange.withValues(alpha: 0.12),
+                      color: AppColors.amber.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(12),
                       border: Border.all(
-                        color: Colors.orange.withValues(alpha: 0.4),
+                        color: AppColors.amber.withValues(alpha: 0.4),
                       ),
                     ),
                     child: Text(
                       state.lastAlert!,
-                      style:
-                          const TextStyle(color: Colors.orange, fontSize: 13),
+                      style: const TextStyle(
+                        color: AppColors.amber,
+                        fontSize: 13,
+                      ),
                     ),
                   ),
                 ],
@@ -180,26 +190,30 @@ class _NavButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const accentPurple = Color(0xFF8A2BE2);
-
     return SizedBox(
       width: double.infinity,
+      height: 52,
       child: ElevatedButton.icon(
         onPressed: onTap,
         style: ElevatedButton.styleFrom(
-          backgroundColor: accentPurple,
-          padding: const EdgeInsets.symmetric(vertical: 16),
+          backgroundColor: AppColors.bgSurface,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 14),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(14),
+            side: BorderSide(
+              color: AppColors.orange.withValues(alpha: 0.5),
+            ),
           ),
+          elevation: 0,
         ),
-        icon: Icon(icon, color: Colors.white),
+        icon: Icon(icon, color: AppColors.orange, size: 20),
         label: Text(
           label,
           style: const TextStyle(
             color: Colors.white,
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
           ),
         ),
       ),

--- a/lib/src/screens/home_page/home_page.dart
+++ b/lib/src/screens/home_page/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/presentation/cubits/dashboard_cubit.dart';
 import 'package:test1/src/bloc/connection/connection_bloc.dart';
 import 'package:test1/src/bloc/connection/connection_state.dart' as connection;
@@ -39,8 +40,6 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    const darkBackground = Color(0xFF1A1B2D);
-
     return BlocProvider<DashboardCubit>.value(
       value: _dashboardCubit,
       child: BlocListener<ConnectionBloc, connection.ConnectionState>(
@@ -50,11 +49,19 @@ class _HomePageState extends State<HomePage> {
           }
         },
         child: Scaffold(
-          backgroundColor: darkBackground,
+          backgroundColor: AppColors.bgDeep,
           appBar: AppBar(
             automaticallyImplyLeading: false,
-            backgroundColor: darkBackground,
+            backgroundColor: AppColors.bgSurface,
             foregroundColor: Colors.white,
+            elevation: 0,
+            bottom: PreferredSize(
+              preferredSize: const Size.fromHeight(1),
+              child: Container(
+                height: 1,
+                color: AppColors.orange.withValues(alpha: 0.3),
+              ),
+            ),
             title: BlocBuilder<DashboardCubit, DashboardState>(
               buildWhen: (prev, next) =>
                   prev.runtimeType != next.runtimeType ||
@@ -70,30 +77,29 @@ class _HomePageState extends State<HomePage> {
                     onSelected: _dashboardCubit.switchLocation,
                   );
                 }
-                return const Text('Чіпідізєль');
+                return const Text(
+                  'Чіпідізєль',
+                  style: TextStyle(color: Colors.white),
+                );
               },
             ),
             actions: [
               IconButton(
-                icon: const Icon(Icons.exit_to_app),
+                icon: const Icon(Icons.exit_to_app, color: Colors.white54),
                 tooltip: 'Вийти',
                 onPressed: () => _logout(context),
               ),
             ],
           ),
-          body: Stack(
-            children: [
-              Container(
-                decoration: const BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [darkBackground, Color(0xFF25274D)],
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                  ),
-                ),
+          body: const DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [AppColors.bgDeep, Color(0xFF140800)],
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
               ),
-              const SafeArea(child: HomeContent()),
-            ],
+            ),
+            child: SafeArea(child: HomeContent()),
           ),
         ),
       ),
@@ -122,8 +128,8 @@ class _LocationSelector extends StatelessWidget {
     }
     return DropdownButton<String>(
       value: activeId,
-      dropdownColor: const Color(0xFF25274D),
-      iconEnabledColor: Colors.white,
+      dropdownColor: AppColors.bgElevated,
+      iconEnabledColor: AppColors.orangeWarm,
       underline: const SizedBox.shrink(),
       style: const TextStyle(
         color: Colors.white,

--- a/lib/src/screens/sensors_page/sensors_page.dart
+++ b/lib/src/screens/sensors_page/sensors_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/presentation/cubits/sensors_cubit.dart';
 
 class SensorsPage extends StatefulWidget {
@@ -30,7 +31,10 @@ class _SensorsPageState extends State<SensorsPage> {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
-      backgroundColor: Colors.transparent,
+      backgroundColor: AppColors.bgElevated,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
       builder: (_) => BlocProvider.value(
         value: _cubit,
         child: _AddLocationSheet(
@@ -47,131 +51,137 @@ class _SensorsPageState extends State<SensorsPage> {
     return BlocProvider<SensorsCubit>.value(
       value: _cubit,
       child: Scaffold(
-        backgroundColor: const Color(0xFF1A1B2D),
+        backgroundColor: AppColors.bgDeep,
         appBar: AppBar(
-          backgroundColor: const Color(0xFF1A1B2D),
+          backgroundColor: AppColors.bgSurface,
           foregroundColor: Colors.white,
+          elevation: 0,
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(1),
+            child: Container(
+              height: 1,
+              color: AppColors.orange.withValues(alpha: 0.3),
+            ),
+          ),
           title: const Text('Сенсори'),
           actions: [
             IconButton(
-              icon: const Icon(Icons.add),
+              icon: const Icon(Icons.add, color: AppColors.orangeWarm),
               tooltip: 'Додати локацію',
               onPressed: _showAddLocationSheet,
             ),
           ],
         ),
-        body: Stack(
-          children: [
-            Container(
-              decoration: const BoxDecoration(
-                gradient: LinearGradient(
-                  colors: [Color(0xFF1A1B2D), Color(0xFF25274D)],
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                ),
-              ),
+        body: DecoratedBox(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              colors: [AppColors.bgDeep, Color(0xFF140800)],
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
             ),
-            BlocBuilder<SensorsCubit, SensorsState>(
-              builder: (context, state) {
-                if (state is SensorsLoading) {
-                  return const Center(
-                    child: CircularProgressIndicator(color: Colors.white),
-                  );
-                }
-                if (state is SensorsError) {
+          ),
+          child: BlocBuilder<SensorsCubit, SensorsState>(
+            builder: (context, state) {
+              if (state is SensorsLoading) {
+                return const Center(
+                  child: CircularProgressIndicator(color: AppColors.orange),
+                );
+              }
+              if (state is SensorsError) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          state.message,
+                          style: const TextStyle(
+                            color: Colors.redAccent,
+                            fontSize: 16,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 16),
+                        TextButton(
+                          onPressed: () =>
+                              context.read<SensorsCubit>().load(),
+                          child: const Text(
+                            'Спробувати знову',
+                            style: TextStyle(color: AppColors.orangeWarm),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              }
+              if (state is SensorsLoaded) {
+                if (state.locations.isEmpty) {
                   return Center(
-                    child: Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            state.message,
-                            style: const TextStyle(
-                              color: Colors.redAccent,
-                              fontSize: 16,
-                            ),
-                            textAlign: TextAlign.center,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(
+                          Icons.location_off_outlined,
+                          color: Colors.white24,
+                          size: 72,
+                        ),
+                        const SizedBox(height: 16),
+                        const Text(
+                          'Додайте першу локацію',
+                          style: TextStyle(
+                            color: Colors.white54,
+                            fontSize: 18,
                           ),
-                          const SizedBox(height: 16),
-                          TextButton(
-                            onPressed: () =>
-                                context.read<SensorsCubit>().load(),
-                            child: const Text(
-                              'Спробувати знову',
-                              style: TextStyle(color: Colors.tealAccent),
+                        ),
+                        const SizedBox(height: 24),
+                        OutlinedButton.icon(
+                          onPressed: _showAddLocationSheet,
+                          icon: const Icon(
+                            Icons.add,
+                            color: AppColors.orangeWarm,
+                          ),
+                          label: const Text(
+                            'Додати локацію',
+                            style: TextStyle(color: AppColors.orangeWarm),
+                          ),
+                          style: OutlinedButton.styleFrom(
+                            side: const BorderSide(
+                              color: AppColors.orangeWarm,
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
                             ),
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                   );
                 }
-                if (state is SensorsLoaded) {
-                  if (state.locations.isEmpty) {
-                    return Center(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const Icon(
-                            Icons.location_off_outlined,
-                            color: Colors.white24,
-                            size: 72,
-                          ),
-                          const SizedBox(height: 16),
-                          const Text(
-                            'Додайте першу локацію',
-                            style: TextStyle(
-                              color: Colors.white54,
-                              fontSize: 18,
-                            ),
-                          ),
-                          const SizedBox(height: 24),
-                          OutlinedButton.icon(
-                            onPressed: _showAddLocationSheet,
-                            icon: const Icon(
-                              Icons.add,
-                              color: Colors.tealAccent,
-                            ),
-                            label: const Text(
-                              'Додати локацію',
-                              style: TextStyle(color: Colors.tealAccent),
-                            ),
-                            style: OutlinedButton.styleFrom(
-                              side: const BorderSide(color: Colors.tealAccent),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  }
-                  return RefreshIndicator(
-                    onRefresh: () => context.read<SensorsCubit>().load(),
-                    color: const Color(0xFF8A2BE2),
-                    backgroundColor: const Color(0xFF25274D),
-                    child: ListView.builder(
-                      padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
-                      itemCount: state.locations.length,
-                      itemBuilder: (context, index) {
-                        final location = state.locations[index];
-                        final sensors =
-                            state.sensorsByLocation[location['id'] as String] ??
-                                [];
-                        return _LocationTile(
-                          location: location,
-                          sensors: sensors,
-                        );
-                      },
-                    ),
-                  );
-                }
-                return const SizedBox.shrink();
-              },
-            ),
-          ],
+                return RefreshIndicator(
+                  onRefresh: () => context.read<SensorsCubit>().load(),
+                  color: AppColors.orange,
+                  backgroundColor: AppColors.bgElevated,
+                  child: ListView.builder(
+                    padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
+                    itemCount: state.locations.length,
+                    itemBuilder: (context, index) {
+                      final location = state.locations[index];
+                      final sensors =
+                          state.sensorsByLocation[location['id'] as String] ??
+                              [];
+                      return _LocationTile(
+                        location: location,
+                        sensors: sensors,
+                      );
+                    },
+                  ),
+                );
+              }
+              return const SizedBox.shrink();
+            },
+          ),
         ),
       ),
     );
@@ -196,7 +206,7 @@ class _LocationTile extends StatelessWidget {
       confirmDismiss: (_) => showDialog<bool>(
         context: context,
         builder: (ctx) => AlertDialog(
-          backgroundColor: const Color(0xFF25274D),
+          backgroundColor: AppColors.bgElevated,
           title: const Text(
             'Видалити локацію?',
             style: TextStyle(color: Colors.white),
@@ -246,18 +256,16 @@ class _LocationTile extends StatelessWidget {
       child: Container(
         margin: const EdgeInsets.only(bottom: 8),
         decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.05),
+          color: AppColors.bgSurface,
           borderRadius: BorderRadius.circular(14),
-          border: Border.all(
-            color: Colors.white.withValues(alpha: 0.08),
-          ),
+          border: Border.all(color: AppColors.border),
         ),
         child: ExpansionTile(
           collapsedIconColor: Colors.white38,
-          iconColor: Colors.white60,
+          iconColor: AppColors.orangeWarm,
           leading: const Icon(
             Icons.location_on_outlined,
-            color: Colors.tealAccent,
+            color: AppColors.orange,
           ),
           title: Text(
             name,
@@ -286,13 +294,20 @@ class _LocationTile extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
               child: OutlinedButton.icon(
                 onPressed: () => _showAddSensorSheet(context, id),
-                icon: const Icon(Icons.add, color: Colors.tealAccent, size: 18),
+                icon: const Icon(
+                  Icons.add,
+                  color: AppColors.orangeWarm,
+                  size: 18,
+                ),
                 label: const Text(
                   'Додати сенсор',
-                  style: TextStyle(color: Colors.tealAccent, fontSize: 13),
+                  style: TextStyle(color: AppColors.orangeWarm, fontSize: 13),
                 ),
                 style: OutlinedButton.styleFrom(
-                  side: const BorderSide(color: Colors.tealAccent, width: 0.8),
+                  side: BorderSide(
+                    color: AppColors.orange.withValues(alpha: 0.5),
+                    width: 0.8,
+                  ),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(10),
                   ),
@@ -315,7 +330,10 @@ class _LocationTile extends StatelessWidget {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
-      backgroundColor: Colors.transparent,
+      backgroundColor: AppColors.bgElevated,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
       builder: (_) => BlocProvider.value(
         value: cubit,
         child: _AddSensorSheet(
@@ -347,7 +365,7 @@ class _SensorTile extends StatelessWidget {
       confirmDismiss: (_) => showDialog<bool>(
         context: context,
         builder: (ctx) => AlertDialog(
-          backgroundColor: const Color(0xFF25274D),
+          backgroundColor: AppColors.bgElevated,
           title: const Text(
             'Видалити сенсор?',
             style: TextStyle(color: Colors.white),
@@ -393,7 +411,7 @@ class _SensorTile extends StatelessWidget {
         contentPadding: const EdgeInsets.symmetric(horizontal: 20),
         leading: Icon(
           _iconFor(type),
-          color: Colors.tealAccent.withValues(alpha: 0.7),
+          color: AppColors.orangeWarm.withValues(alpha: 0.8),
           size: 22,
         ),
         title: Text(
@@ -449,12 +467,8 @@ class _AddLocationSheetState extends State<_AddLocationSheet> {
   @override
   Widget build(BuildContext context) {
     final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
-    return Container(
+    return Padding(
       padding: EdgeInsets.fromLTRB(20, 24, 20, 20 + bottomInset),
-      decoration: const BoxDecoration(
-        color: Color(0xFF25274D),
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -473,26 +487,34 @@ class _AddLocationSheetState extends State<_AddLocationSheet> {
           const SizedBox(height: 12),
           _DarkTextField(controller: _addressController, label: 'Адреса'),
           const SizedBox(height: 20),
-          ElevatedButton(
-            onPressed: _isSubmitting ? null : _submit,
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.teal,
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(vertical: 14),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+          SizedBox(
+            height: 50,
+            child: ElevatedButton(
+              onPressed: _isSubmitting ? null : _submit,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.orange,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
               ),
-            ),
-            child: _isSubmitting
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(
-                      color: Colors.white,
-                      strokeWidth: 2,
+              child: _isSubmitting
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                        strokeWidth: 2,
+                      ),
+                    )
+                  : const Text(
+                      'Додати',
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
-                  )
-                : const Text('Додати'),
+            ),
           ),
         ],
       ),
@@ -545,12 +567,8 @@ class _AddSensorSheetState extends State<_AddSensorSheet> {
   Widget build(BuildContext context) {
     final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
     final (_, unit) = _types[_selectedType]!;
-    return Container(
+    return Padding(
       padding: EdgeInsets.fromLTRB(20, 24, 20, 20 + bottomInset),
-      decoration: const BoxDecoration(
-        color: Color(0xFF25274D),
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -569,7 +587,7 @@ class _AddSensorSheetState extends State<_AddSensorSheet> {
           const SizedBox(height: 12),
           DropdownButtonFormField<String>(
             value: _selectedType,
-            dropdownColor: const Color(0xFF1A1B2D),
+            dropdownColor: AppColors.bgElevated,
             style: const TextStyle(color: Colors.white),
             decoration: InputDecoration(
               labelText: 'Тип',
@@ -590,7 +608,7 @@ class _AddSensorSheetState extends State<_AddSensorSheet> {
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(color: Colors.tealAccent),
+                borderSide: const BorderSide(color: AppColors.orange),
               ),
             ),
             items: _types.entries.map((e) {
@@ -605,10 +623,10 @@ class _AddSensorSheetState extends State<_AddSensorSheet> {
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.04),
+              color: AppColors.orange.withValues(alpha: 0.07),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: AppColors.orange.withValues(alpha: 0.25),
               ),
             ),
             child: Row(
@@ -620,7 +638,7 @@ class _AddSensorSheetState extends State<_AddSensorSheet> {
                 Text(
                   unit,
                   style: const TextStyle(
-                    color: Colors.tealAccent,
+                    color: AppColors.orangeWarm,
                     fontSize: 14,
                     fontWeight: FontWeight.bold,
                   ),
@@ -629,26 +647,34 @@ class _AddSensorSheetState extends State<_AddSensorSheet> {
             ),
           ),
           const SizedBox(height: 20),
-          ElevatedButton(
-            onPressed: _isSubmitting ? null : _submit,
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.teal,
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(vertical: 14),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+          SizedBox(
+            height: 50,
+            child: ElevatedButton(
+              onPressed: _isSubmitting ? null : _submit,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.orange,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
               ),
-            ),
-            child: _isSubmitting
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(
-                      color: Colors.white,
-                      strokeWidth: 2,
+              child: _isSubmitting
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                        strokeWidth: 2,
+                      ),
+                    )
+                  : const Text(
+                      'Додати',
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
-                  )
-                : const Text('Додати'),
+            ),
           ),
         ],
       ),
@@ -696,7 +722,7 @@ class _DarkTextField extends StatelessWidget {
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: Colors.tealAccent),
+          borderSide: const BorderSide(color: AppColors.orange),
         ),
       ),
     );

--- a/lib/src/screens/telemetry/telemetry_page.dart
+++ b/lib/src/screens/telemetry/telemetry_page.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
 import 'package:test1/data/repositories/sensor_repository.dart';
 import 'package:test1/src/bloc/connection/connection_bloc.dart';
 import 'package:test1/src/bloc/connection/connection_state.dart' as conn;
@@ -27,7 +28,6 @@ class TelemetryPage extends StatefulWidget {
 
 class _TelemetryPageState extends State<TelemetryPage>
     with SingleTickerProviderStateMixin {
-  static const _darkBackground = Color(0xFF1A1B2D);
   static const _typeOrder = {'temperature': 0, 'humidity': 1, 'pressure': 2};
 
   final _sensorRepo = SensorRepository();
@@ -127,6 +127,10 @@ class _TelemetryPageState extends State<TelemetryPage>
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
+      backgroundColor: AppColors.bgElevated,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
       builder: (_) => ThresholdSettingsWidget(
         sensorId: sensor['id'] as String,
         label: _labelFor(sensor['type'] as String),
@@ -156,7 +160,7 @@ class _TelemetryPageState extends State<TelemetryPage>
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
-      backgroundColor: const Color(0xFF25274D),
+      backgroundColor: AppColors.bgElevated,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
@@ -179,26 +183,18 @@ class _TelemetryPageState extends State<TelemetryPage>
 
     if (sensors == null) {
       return Scaffold(
-        backgroundColor: _darkBackground,
-        appBar: AppBar(
-          backgroundColor: _darkBackground,
-          foregroundColor: Colors.white,
-          title: const Text('Телеметрія'),
-        ),
+        backgroundColor: AppColors.bgDeep,
+        appBar: _buildAppBar(null),
         body: const Center(
-          child: CircularProgressIndicator(color: Colors.white),
+          child: CircularProgressIndicator(color: AppColors.orange),
         ),
       );
     }
 
     if (sensors.isEmpty) {
       return Scaffold(
-        backgroundColor: _darkBackground,
-        appBar: AppBar(
-          backgroundColor: _darkBackground,
-          foregroundColor: Colors.white,
-          title: const Text('Телеметрія'),
-        ),
+        backgroundColor: AppColors.bgDeep,
+        appBar: _buildAppBar(null),
         body: Center(
           child: Padding(
             padding: const EdgeInsets.all(24),
@@ -206,7 +202,7 @@ class _TelemetryPageState extends State<TelemetryPage>
               widget.locationId == null
                   ? 'Локацію не вибрано'
                   : 'У цій локації немає сенсорів',
-              style: const TextStyle(color: Colors.white54, fontSize: 16),
+              style: const TextStyle(color: Colors.white38, fontSize: 16),
               textAlign: TextAlign.center,
             ),
           ),
@@ -215,45 +211,73 @@ class _TelemetryPageState extends State<TelemetryPage>
     }
 
     return Scaffold(
-      backgroundColor: _darkBackground,
-      appBar: AppBar(
-        backgroundColor: _darkBackground,
-        foregroundColor: Colors.white,
-        title: const Text('Телеметрія'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.file_download_outlined),
-            tooltip: 'Експорт CSV',
-            onPressed: () => _openExportSheet(context),
+      backgroundColor: AppColors.bgDeep,
+      appBar: _buildAppBar(sensors),
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [AppColors.bgDeep, Color(0xFF140800)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
           ),
-          IconButton(
-            icon: const Icon(Icons.tune),
-            tooltip: 'Налаштування порогів',
-            onPressed: () => _openThresholdSettings(context),
-          ),
-        ],
-        bottom: TabBar(
+        ),
+        child: TabBarView(
           controller: _tabController,
-          labelColor: Colors.white,
-          unselectedLabelColor: Colors.white54,
-          indicatorColor: const Color(0xFF8A2BE2),
-          tabs: sensors
-              .map((s) => Tab(text: _labelFor(s['type'] as String)))
-              .toList(),
-        ),
-      ),
-      body: TabBarView(
-        controller: _tabController,
-        children: List.generate(
-          sensors.length,
-          (i) => _TelemetryTabView(
-            cubit: _telemetryCubits[i],
-            thresholdCubit: _thresholdCubits[i],
-            unit: sensors[i]['unit'] as String,
-            label: _labelFor(sensors[i]['type'] as String),
+          children: List.generate(
+            sensors.length,
+            (i) => _TelemetryTabView(
+              cubit: _telemetryCubits[i],
+              thresholdCubit: _thresholdCubits[i],
+              unit: sensors[i]['unit'] as String,
+              label: _labelFor(sensors[i]['type'] as String),
+            ),
           ),
         ),
       ),
+    );
+  }
+
+  AppBar _buildAppBar(List<Map<String, dynamic>>? sensors) {
+    return AppBar(
+      backgroundColor: AppColors.bgSurface,
+      foregroundColor: Colors.white,
+      elevation: 0,
+      title: const Text('Телеметрія'),
+      actions: sensors != null
+          ? [
+              IconButton(
+                icon: const Icon(
+                  Icons.file_download_outlined,
+                  color: AppColors.orangeWarm,
+                ),
+                tooltip: 'Експорт CSV',
+                onPressed: () => _openExportSheet(context),
+              ),
+              IconButton(
+                icon: const Icon(Icons.tune, color: Colors.white54),
+                tooltip: 'Налаштування порогів',
+                onPressed: () => _openThresholdSettings(context),
+              ),
+            ]
+          : null,
+      bottom: sensors != null
+          ? TabBar(
+              controller: _tabController,
+              labelColor: AppColors.orange,
+              unselectedLabelColor: Colors.white38,
+              indicatorColor: AppColors.orange,
+              indicatorWeight: 3,
+              tabs: sensors
+                  .map((s) => Tab(text: _labelFor(s['type'] as String)))
+                  .toList(),
+            )
+          : PreferredSize(
+              preferredSize: const Size.fromHeight(1),
+              child: Container(
+                height: 1,
+                color: AppColors.orange.withValues(alpha: 0.3),
+              ),
+            ),
     );
   }
 }
@@ -286,8 +310,8 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
       builder: (context, child) => Theme(
         data: Theme.of(context).copyWith(
           colorScheme: const ColorScheme.dark(
-            primary: Color(0xFF8A2BE2),
-            surface: Color(0xFF25274D),
+            primary: AppColors.orange,
+            surface: AppColors.bgElevated,
           ),
         ),
         child: child!,
@@ -355,7 +379,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
           const SizedBox(height: 4),
           const Text(
             'Оберіть діапазон дат для CSV-файлу',
-            style: TextStyle(color: Colors.white54, fontSize: 13),
+            style: TextStyle(color: Colors.white38, fontSize: 13),
           ),
           const SizedBox(height: 20),
           Row(
@@ -381,13 +405,14 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
           ),
           const SizedBox(height: 20),
           SizedBox(
-            height: 48,
+            height: 50,
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF8A2BE2),
+                backgroundColor: AppColors.orange,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),
                 ),
+                padding: EdgeInsets.zero,
               ),
               onPressed: _loading ? null : _export,
               child: _loading
@@ -434,17 +459,24 @@ class _DateButton extends StatelessWidget {
       style: OutlinedButton.styleFrom(
         foregroundColor: Colors.white,
         side: BorderSide(
-          color: enabled ? Colors.white38 : Colors.white12,
+          color: enabled
+              ? AppColors.orange.withValues(alpha: 0.5)
+              : AppColors.border,
         ),
         padding: const EdgeInsets.symmetric(vertical: 12),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
       ),
       onPressed: enabled ? onTap : null,
       child: Column(
         children: [
           Text(
             label,
-            style: const TextStyle(color: Colors.white54, fontSize: 11),
+            style: const TextStyle(
+              color: AppColors.orangeWarm,
+              fontSize: 11,
+            ),
           ),
           const SizedBox(height: 2),
           Text(date, style: const TextStyle(fontSize: 14)),
@@ -474,7 +506,7 @@ class _TelemetryTabView extends StatelessWidget {
       builder: (context, state) {
         if (state is TelemetryLoading || state is TelemetryInitial) {
           return const Center(
-            child: CircularProgressIndicator(color: Colors.white),
+            child: CircularProgressIndicator(color: AppColors.orange),
           );
         }
 
@@ -519,15 +551,16 @@ class _TelemetryTabView extends StatelessWidget {
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                      const SizedBox(height: 4),
+                      const SizedBox(height: 2),
                       Text(
                         label,
                         style: const TextStyle(
-                          color: Colors.white54,
-                          fontSize: 16,
+                          color: AppColors.orange,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
                         ),
                       ),
-                      const SizedBox(height: 24),
+                      const SizedBox(height: 20),
                     ],
                     Expanded(
                       child: TelemetryChartWidget(

--- a/lib/src/widgets/reusable/reusable_text.dart
+++ b/lib/src/widgets/reusable/reusable_text.dart
@@ -13,14 +13,10 @@ class ReusableTextField extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: TextField(
-          controller: controller,
-          obscureText: obscure,
-          decoration: InputDecoration(
-            labelText: hint,
-          ),
-        ),
+  Widget build(BuildContext context) => TextField(
+        controller: controller,
+        obscureText: obscure,
+        style: const TextStyle(color: Colors.white),
+        decoration: InputDecoration(labelText: hint),
       );
 }

--- a/lib/src/widgets/telemetry_chart_widget.dart
+++ b/lib/src/widgets/telemetry_chart_widget.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:test1/core/app_colors.dart';
 
 class TelemetryChartWidget extends StatelessWidget {
   final List<Map<String, dynamic>> points;
@@ -15,18 +16,12 @@ class TelemetryChartWidget extends StatelessWidget {
     super.key,
   });
 
-  Color get _lineColor {
-    switch (unit) {
-      case '°C':
-        return Colors.redAccent;
-      case '%':
-        return Colors.blueAccent;
-      case 'hPa':
-        return Colors.greenAccent;
-      default:
-        return Colors.purpleAccent;
-    }
-  }
+  Color get _lineColor => switch (unit) {
+        '°C'  => AppColors.orange,
+        '%'   => AppColors.amber,
+        'hPa' => AppColors.orangeWarm,
+        _     => AppColors.orange,
+      };
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +32,7 @@ class TelemetryChartWidget extends StatelessWidget {
       return const Center(
         child: Text(
           'Немає даних для відображення',
-          style: TextStyle(color: Colors.white54),
+          style: TextStyle(color: Colors.white38),
         ),
       );
     }
@@ -104,7 +99,14 @@ class TelemetryChartWidget extends StatelessWidget {
             dotData: const FlDotData(show: false),
             belowBarData: BarAreaData(
               show: true,
-              color: color.withValues(alpha: 0.15),
+              gradient: LinearGradient(
+                colors: [
+                  color.withValues(alpha: 0.25),
+                  color.withValues(alpha: 0),
+                ],
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+              ),
             ),
           ),
         ],
@@ -117,7 +119,10 @@ class TelemetryChartWidget extends StatelessWidget {
                 padding: const EdgeInsets.only(right: 4),
                 child: Text(
                   '${value.toStringAsFixed(1)} $unit',
-                  style: const TextStyle(color: Colors.white60, fontSize: 10),
+                  style: const TextStyle(
+                    color: Colors.white38,
+                    fontSize: 10,
+                  ),
                 ),
               ),
             ),
@@ -128,16 +133,27 @@ class TelemetryChartWidget extends StatelessWidget {
         ),
         borderData: FlBorderData(
           show: true,
-          border: Border.all(color: Colors.white24),
+          border: Border.all(color: AppColors.border),
+        ),
+        gridData: FlGridData(
+          drawVerticalLine: false,
+          getDrawingHorizontalLine: (_) => const FlLine(
+            color: AppColors.border,
+            strokeWidth: 0.8,
+          ),
         ),
         lineTouchData: LineTouchData(
           touchTooltipData: LineTouchTooltipData(
-            getTooltipColor: (_) => Colors.black87,
+            getTooltipColor: (_) => AppColors.bgElevated,
             getTooltipItems: (spots) => spots
                 .map(
                   (spot) => LineTooltipItem(
                     '${spot.y.toStringAsFixed(2)} $unit',
-                    const TextStyle(color: Colors.white, fontSize: 12),
+                    TextStyle(
+                      color: color,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 )
                 .toList(),


### PR DESCRIPTION
Introduce AppColors palette (bgDeep, bgSurface, bgElevated, border, orange, orangeWarm, amber) and apply consistently to all screens: auth, home, telemetry, events, sensors. Charts use gradient fills, AppBar gets thin orange bottom border, buttons switch from teal to orange.