### PR TITLE
feat: add onboarding and user profile screens

### DIFF
--- a/lib/core/auth_guard.dart
+++ b/lib/core/auth_guard.dart
@@ -1,26 +1,64 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
+import 'package:test1/data/repositories/location_repository.dart';
 import 'package:test1/src/cubit/auth/auth_cubit.dart';
 import 'package:test1/src/screens/auth_page/login_page.dart';
-import 'package:test1/src/screens/home_page/home_page.dart';
 
-class AuthGuard extends StatelessWidget {
+class AuthGuard extends StatefulWidget {
   const AuthGuard({super.key});
 
   @override
+  State<AuthGuard> createState() => _AuthGuardState();
+}
+
+class _AuthGuardState extends State<AuthGuard> {
+  bool _checking = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final state = context.read<AuthCubit>().state;
+    if (state is AuthAuthenticated) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _checkLocations());
+    }
+  }
+
+  Future<void> _checkLocations() async {
+    if (_checking || !mounted) return;
+    _checking = true;
+    try {
+      final locations = await LocationRepository().getLocations();
+      if (!mounted) return;
+      await Navigator.pushReplacementNamed(
+        context,
+        locations.isEmpty ? '/onboarding' : '/home',
+      );
+    } catch (_) {
+      if (!mounted) return;
+      await Navigator.pushReplacementNamed(context, '/home');
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BlocBuilder<AuthCubit, AuthState>(
+    return BlocConsumer<AuthCubit, AuthState>(
+      listener: (context, state) {
+        if (state is AuthAuthenticated) {
+          _checkLocations();
+        }
+      },
       builder: (context, state) {
-        if (state is AuthLoading || state is AuthInitial) {
+        if (state is AuthLoading ||
+            state is AuthInitial ||
+            state is AuthAuthenticated) {
           return const Scaffold(
-            body: Center(child: CircularProgressIndicator()),
+            backgroundColor: AppColors.bgDeep,
+            body: Center(
+              child: CircularProgressIndicator(color: AppColors.orange),
+            ),
           );
         }
-
-        if (state is AuthAuthenticated) {
-          return const HomePage();
-        }
-
         return const LoginPage();
       },
     );

--- a/lib/data/repositories/event_repository.dart
+++ b/lib/data/repositories/event_repository.dart
@@ -5,6 +5,29 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:test1/core/supabase_client.dart';
 
 class EventRepository {
+  Future<int> getTodayEventsCount() async {
+    try {
+      final todayStart = DateTime(
+        DateTime.now().year,
+        DateTime.now().month,
+        DateTime.now().day,
+      ).toUtc().toIso8601String();
+      final response = await supabase
+          .from('events')
+          .select('id')
+          .gte('triggered_at', todayStart);
+      return response.length;
+    } catch (error, stackTrace) {
+      log(
+        'Failed to count today events',
+        name: 'EventRepository',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   Future<List<Map<String, dynamic>>> getEvents({int limit = 50}) async {
     try {
       final response = await supabase

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,8 @@ import 'package:test1/src/screens/auth_page/login_page.dart';
 import 'package:test1/src/screens/auth_page/register_page.dart';
 import 'package:test1/src/screens/events_page/events_page.dart';
 import 'package:test1/src/screens/home_page/home_page.dart';
+import 'package:test1/src/screens/onboarding_page/onboarding_page.dart';
+import 'package:test1/src/screens/profile_page/profile_page.dart';
 import 'package:test1/src/screens/sensors_page/sensors_page.dart';
 import 'package:test1/src/screens/telemetry/telemetry_page.dart';
 import 'package:test1/src/services/push_mess/fcm_service.dart';
@@ -155,6 +157,12 @@ class MyApp extends StatelessWidget {
             return MaterialPageRoute(builder: (_) => const EventsPage());
           case '/sensors':
             return MaterialPageRoute(builder: (_) => const SensorsPage());
+          case '/onboarding':
+            return MaterialPageRoute(
+              builder: (_) => const OnboardingPage(),
+            );
+          case '/profile':
+            return MaterialPageRoute(builder: (_) => const ProfilePage());
           default:
             return MaterialPageRoute(
               builder: (_) => const Scaffold(

--- a/lib/src/cubit/profile/profile_cubit.dart
+++ b/lib/src/cubit/profile/profile_cubit.dart
@@ -1,0 +1,39 @@
+import 'dart:developer';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/data/repositories/event_repository.dart';
+import 'package:test1/data/repositories/location_repository.dart';
+import 'package:test1/data/repositories/sensor_repository.dart';
+
+part 'profile_state.dart';
+
+class ProfileCubit extends Cubit<ProfileState> {
+  ProfileCubit() : super(ProfileInitial());
+
+  Future<void> load() async {
+    emit(ProfileLoading());
+    try {
+      final locationsFuture = LocationRepository().getLocations();
+      final sensorsFuture = SensorRepository().getAllSensors();
+      final countFuture = EventRepository().getTodayEventsCount();
+
+      final locations = await locationsFuture;
+      final sensors = await sensorsFuture;
+      final todayEventCount = await countFuture;
+
+      emit(ProfileLoaded(
+        locationCount: locations.length,
+        sensorCount: sensors.length,
+        todayEventCount: todayEventCount,
+      ),);
+    } catch (error, stackTrace) {
+      log(
+        'Failed to load profile stats',
+        name: 'ProfileCubit',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      emit(const ProfileError('Не вдалося завантажити дані профілю'));
+    }
+  }
+}

--- a/lib/src/cubit/profile/profile_state.dart
+++ b/lib/src/cubit/profile/profile_state.dart
@@ -1,0 +1,27 @@
+part of 'profile_cubit.dart';
+
+abstract class ProfileState {
+  const ProfileState();
+}
+
+class ProfileInitial extends ProfileState {}
+
+class ProfileLoading extends ProfileState {}
+
+class ProfileLoaded extends ProfileState {
+  final int locationCount;
+  final int sensorCount;
+  final int todayEventCount;
+
+  const ProfileLoaded({
+    required this.locationCount,
+    required this.sensorCount,
+    required this.todayEventCount,
+  });
+}
+
+class ProfileError extends ProfileState {
+  final String message;
+
+  const ProfileError(this.message);
+}

--- a/lib/src/screens/auth_page/login_form.dart
+++ b/lib/src/screens/auth_page/login_form.dart
@@ -30,8 +30,8 @@ class LoginForm extends StatelessWidget {
             if (context.mounted) {
               Navigator.pushNamedAndRemoveUntil(
                 context,
-                '/home',
-                (Route<dynamic> route) => true,
+                '/',
+                (Route<dynamic> route) => false,
               );
             }
           });

--- a/lib/src/screens/auth_page/register_page.dart
+++ b/lib/src/screens/auth_page/register_page.dart
@@ -13,7 +13,11 @@ class RegisterPage extends StatelessWidget {
     return BlocListener<AuthCubit, AuthState>(
       listener: (context, state) {
         if (state is AuthAuthenticated) {
-          Navigator.pushReplacementNamed(context, '/home');
+          Navigator.pushNamedAndRemoveUntil(
+            context,
+            '/',
+            (Route<dynamic> route) => false,
+          );
         }
       },
       child: Scaffold(

--- a/lib/src/screens/home_page/home_page.dart
+++ b/lib/src/screens/home_page/home_page.dart
@@ -4,7 +4,6 @@ import 'package:test1/core/app_colors.dart';
 import 'package:test1/presentation/cubits/dashboard_cubit.dart';
 import 'package:test1/src/bloc/connection/connection_bloc.dart';
 import 'package:test1/src/bloc/connection/connection_state.dart' as connection;
-import 'package:test1/src/cubit/auth/auth_cubit.dart';
 import 'package:test1/src/screens/home_page/home_content.dart';
 
 class HomePage extends StatefulWidget {
@@ -29,13 +28,6 @@ class _HomePageState extends State<HomePage> {
   void dispose() {
     _dashboardCubit.close();
     super.dispose();
-  }
-
-  Future<void> _logout(BuildContext context) async {
-    await context.read<AuthCubit>().signOut();
-    if (context.mounted) {
-      Navigator.pushReplacementNamed(context, '/login');
-    }
   }
 
   @override
@@ -85,9 +77,12 @@ class _HomePageState extends State<HomePage> {
             ),
             actions: [
               IconButton(
-                icon: const Icon(Icons.exit_to_app, color: Colors.white54),
-                tooltip: 'Вийти',
-                onPressed: () => _logout(context),
+                icon: const Icon(
+                  Icons.account_circle_outlined,
+                  color: Colors.white54,
+                ),
+                tooltip: 'Профіль',
+                onPressed: () => Navigator.pushNamed(context, '/profile'),
               ),
             ],
           ),

--- a/lib/src/screens/onboarding_page/onboarding_page.dart
+++ b/lib/src/screens/onboarding_page/onboarding_page.dart
@@ -1,0 +1,404 @@
+import 'package:flutter/material.dart';
+import 'package:test1/core/app_colors.dart';
+import 'package:test1/data/repositories/location_repository.dart';
+
+class OnboardingPage extends StatefulWidget {
+  const OnboardingPage({super.key});
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final _pageController = PageController();
+  int _currentPage = 0;
+
+  static const _pages = [
+    _PageData(
+      icon: Icons.sensors,
+      title: 'Система телеметрії',
+      subtitle:
+          'Моніторинг температури, вологості та тиску у реальному часі',
+    ),
+    _PageData(
+      icon: Icons.location_on,
+      title: 'Додайте локацію',
+      subtitle: 'Створіть перше приміщення для моніторингу',
+    ),
+    _PageData(
+      icon: Icons.add_circle_outline,
+      title: 'Додайте сенсори',
+      subtitle: 'Підключіть сенсори до локації',
+    ),
+  ];
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _next() {
+    if (_currentPage < _pages.length - 1) {
+      _pageController.nextPage(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    } else {
+      _showCreateLocationSheet();
+    }
+  }
+
+  void _skip() => Navigator.pushReplacementNamed(context, '/home');
+
+  void _showCreateLocationSheet() {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.bgElevated,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => _CreateLocationSheet(
+        onCreated: () {
+          if (mounted) Navigator.pushReplacementNamed(context, '/home');
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.bgDeep,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        foregroundColor: Colors.white,
+        elevation: 0,
+        automaticallyImplyLeading: false,
+        actions: [
+          TextButton(
+            onPressed: _skip,
+            child: const Text(
+              'Пропустити',
+              style: TextStyle(
+                color: AppColors.orangeWarm,
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [AppColors.bgDeep, Color(0xFF140800)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              Expanded(
+                child: PageView.builder(
+                  controller: _pageController,
+                  itemCount: _pages.length,
+                  onPageChanged: (i) => setState(() => _currentPage = i),
+                  itemBuilder: (context, i) =>
+                      _OnboardingStep(data: _pages[i]),
+                ),
+              ),
+              _PageIndicator(
+                count: _pages.length,
+                current: _currentPage,
+              ),
+              const SizedBox(height: 24),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 0, 24, 40),
+                child: SizedBox(
+                  width: double.infinity,
+                  height: 52,
+                  child: ElevatedButton(
+                    onPressed: _next,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.orange,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      padding: EdgeInsets.zero,
+                    ),
+                    child: Text(
+                      _currentPage < _pages.length - 1
+                          ? 'Далі'
+                          : 'Розпочати',
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PageData {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  const _PageData({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+}
+
+class _OnboardingStep extends StatelessWidget {
+  final _PageData data;
+
+  const _OnboardingStep({required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 120,
+            height: 120,
+            decoration: BoxDecoration(
+              color: AppColors.orange.withValues(alpha: 0.12),
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: AppColors.orange.withValues(alpha: 0.4),
+                width: 2,
+              ),
+            ),
+            child: Icon(data.icon, size: 56, color: AppColors.orange),
+          ),
+          const SizedBox(height: 40),
+          Text(
+            data.title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 26,
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            data.subtitle,
+            style: const TextStyle(
+              color: Colors.white54,
+              fontSize: 16,
+              height: 1.5,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PageIndicator extends StatelessWidget {
+  final int count;
+  final int current;
+
+  const _PageIndicator({required this.count, required this.current});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(count, (i) {
+        final active = i == current;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 250),
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          width: active ? 24 : 8,
+          height: 8,
+          decoration: BoxDecoration(
+            color: active
+                ? AppColors.orange
+                : AppColors.orange.withValues(alpha: 0.3),
+            borderRadius: BorderRadius.circular(4),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class _CreateLocationSheet extends StatefulWidget {
+  final VoidCallback onCreated;
+
+  const _CreateLocationSheet({required this.onCreated});
+
+  @override
+  State<_CreateLocationSheet> createState() => _CreateLocationSheetState();
+}
+
+class _CreateLocationSheetState extends State<_CreateLocationSheet> {
+  final _nameController = TextEditingController();
+  final _addressController = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _addressController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    setState(() => _submitting = true);
+    try {
+      await LocationRepository().createLocation(
+        name,
+        _addressController.text.trim(),
+      );
+      if (!mounted) return;
+      Navigator.pop(context);
+      widget.onCreated();
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Не вдалося створити локацію'),
+          backgroundColor: Colors.red,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(20, 24, 20, 20 + bottomInset),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Перша локація',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'Введіть назву приміщення для моніторингу',
+              style: TextStyle(color: Colors.white38, fontSize: 13),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 20),
+            _SheetTextField(
+              controller: _nameController,
+              label: 'Назва локації',
+              enabled: !_submitting,
+            ),
+            const SizedBox(height: 12),
+            _SheetTextField(
+              controller: _addressController,
+              label: 'Адреса (необов\'язково)',
+              enabled: !_submitting,
+            ),
+            const SizedBox(height: 20),
+            SizedBox(
+              height: 50,
+              child: ElevatedButton(
+                onPressed: _submitting ? null : _submit,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.orange,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  padding: EdgeInsets.zero,
+                ),
+                child: _submitting
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                          color: Colors.white,
+                          strokeWidth: 2,
+                        ),
+                      )
+                    : const Text(
+                        'Створити',
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+              ),
+            ),
+          ],
+        ),
+    );
+  }
+}
+
+class _SheetTextField extends StatelessWidget {
+  final TextEditingController controller;
+  final String label;
+  final bool enabled;
+
+  const _SheetTextField({
+    required this.controller,
+    required this.label,
+    required this.enabled,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      enabled: enabled,
+      style: const TextStyle(color: Colors.white),
+      decoration: InputDecoration(
+        labelText: label,
+        labelStyle: const TextStyle(color: Colors.white54),
+        fillColor: Colors.white.withValues(alpha: 0.05),
+        filled: true,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(
+            color: Colors.white.withValues(alpha: 0.2),
+          ),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(
+            color: Colors.white.withValues(alpha: 0.2),
+          ),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.orange),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/screens/profile_page/profile_page.dart
+++ b/lib/src/screens/profile_page/profile_page.dart
@@ -1,0 +1,309 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test1/core/app_colors.dart';
+import 'package:test1/core/supabase_client.dart';
+import 'package:test1/src/cubit/auth/auth_cubit.dart';
+import 'package:test1/src/cubit/profile/profile_cubit.dart';
+
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  late final ProfileCubit _cubit;
+
+  @override
+  void initState() {
+    super.initState();
+    _cubit = ProfileCubit();
+    _cubit.load();
+  }
+
+  @override
+  void dispose() {
+    _cubit.close();
+    super.dispose();
+  }
+
+  Future<void> _logout() async {
+    await context.read<AuthCubit>().signOut();
+    if (mounted) {
+      Navigator.pushReplacementNamed(context, '/login');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = supabase.auth.currentUser;
+    final email = user?.email ?? '';
+    final avatarLetter =
+        email.isNotEmpty ? email[0].toUpperCase() : '?';
+    final createdAt = user?.createdAt != null
+        ? DateTime.parse(user!.createdAt).toLocal()
+        : null;
+
+    return BlocProvider<ProfileCubit>.value(
+      value: _cubit,
+      child: Scaffold(
+        backgroundColor: AppColors.bgDeep,
+        appBar: AppBar(
+          backgroundColor: AppColors.bgSurface,
+          foregroundColor: Colors.white,
+          elevation: 0,
+          title: const Text('Профіль'),
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(1),
+            child: Container(
+              height: 1,
+              color: AppColors.orange.withValues(alpha: 0.3),
+            ),
+          ),
+        ),
+        body: DecoratedBox(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              colors: [AppColors.bgDeep, Color(0xFF140800)],
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+            ),
+          ),
+          child: SafeArea(
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        _AvatarSection(
+                          letter: avatarLetter,
+                          email: email,
+                          createdAt: createdAt,
+                        ),
+                        const SizedBox(height: 24),
+                        const _SectionLabel('Система'),
+                        const SizedBox(height: 8),
+                        BlocBuilder<ProfileCubit, ProfileState>(
+                          builder: (context, state) {
+                            if (state is ProfileLoading) {
+                              return const Center(
+                                child: Padding(
+                                  padding: EdgeInsets.all(24),
+                                  child: CircularProgressIndicator(
+                                    color: AppColors.orange,
+                                  ),
+                                ),
+                              );
+                            }
+                            if (state is ProfileError) {
+                              return Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Text(
+                                  state.message,
+                                  style: const TextStyle(
+                                    color: Colors.redAccent,
+                                    fontSize: 14,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              );
+                            }
+                            if (state is ProfileLoaded) {
+                              return Column(
+                                children: [
+                                  _StatRow(
+                                    icon: Icons.location_on_outlined,
+                                    label: 'Локації',
+                                    value: '${state.locationCount}',
+                                  ),
+                                  const SizedBox(height: 8),
+                                  _StatRow(
+                                    icon: Icons.sensors,
+                                    label: 'Сенсори',
+                                    value: '${state.sensorCount}',
+                                  ),
+                                  const SizedBox(height: 8),
+                                  _StatRow(
+                                    icon: Icons.warning_amber_outlined,
+                                    label: 'Подій сьогодні',
+                                    value: '${state.todayEventCount}',
+                                  ),
+                                ],
+                              );
+                            }
+                            return const SizedBox.shrink();
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 32),
+                  child: SizedBox(
+                    width: double.infinity,
+                    height: 52,
+                    child: OutlinedButton.icon(
+                      onPressed: _logout,
+                      icon: const Icon(
+                        Icons.exit_to_app,
+                        color: Colors.redAccent,
+                      ),
+                      label: const Text(
+                        'Вийти з акаунта',
+                        style: TextStyle(
+                          color: Colors.redAccent,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      style: OutlinedButton.styleFrom(
+                        side: BorderSide(
+                          color: Colors.redAccent.withValues(alpha: 0.5),
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(14),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AvatarSection extends StatelessWidget {
+  final String letter;
+  final String email;
+  final DateTime? createdAt;
+
+  const _AvatarSection({
+    required this.letter,
+    required this.email,
+    required this.createdAt,
+  });
+
+  String _formatDate(DateTime dt) {
+    final months = [
+      'січня', 'лютого', 'березня', 'квітня', 'травня', 'червня',
+      'липня', 'серпня', 'вересня', 'жовтня', 'листопада', 'грудня',
+    ];
+    return '${dt.day} ${months[dt.month - 1]} ${dt.year}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 88,
+          height: 88,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: AppColors.orange.withValues(alpha: 0.15),
+            border: Border.all(color: AppColors.orange, width: 2),
+          ),
+          child: Center(
+            child: Text(
+              letter,
+              style: const TextStyle(
+                color: AppColors.orange,
+                fontSize: 36,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 14),
+        Text(
+          email,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        if (createdAt != null) ...[
+          const SizedBox(height: 4),
+          Text(
+            'Учасник з ${_formatDate(createdAt!)}',
+            style: const TextStyle(color: Colors.white38, fontSize: 13),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+
+  const _SectionLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text.toUpperCase(),
+      style: const TextStyle(
+        color: AppColors.orangeWarm,
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 1.2,
+      ),
+    );
+  }
+}
+
+class _StatRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _StatRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: AppColors.bgSurface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: AppColors.orangeWarm, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              label,
+              style: const TextStyle(color: Colors.white70, fontSize: 14),
+            ),
+          ),
+          Text(
+            value,
+            style: const TextStyle(
+              color: AppColors.orange,
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
OnboardingPage: 3-step PageView with orange indicators, shown once after first auth when no locations exist; final step opens location creation sheet before navigating to /home.

ProfilePage: avatar with email initial, member-since date, system stats (locations / sensors / today's events), logout button.

AuthGuard: now async — checks location count and routes to /onboarding or /home; login/register navigate to / to re-enter the guard.