### PR TITLE
feat: replace CSV export with Excel (.xlsx) saved to Downloads folder

### DIFF
--- a/lib/src/screens/telemetry/telemetry_page.dart
+++ b/lib/src/screens/telemetry/telemetry_page.dart
@@ -250,7 +250,7 @@ class _TelemetryPageState extends State<TelemetryPage>
                   Icons.file_download_outlined,
                   color: AppColors.orangeWarm,
                 ),
-                tooltip: 'Експорт CSV',
+                tooltip: 'Експорт Excel',
                 onPressed: () => _openExportSheet(context),
               ),
               IconButton(
@@ -335,13 +335,22 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
   Future<void> _export() async {
     setState(() => _loading = true);
     try {
-      await ExportService().exportToCsv(
+      final filename = await ExportService().exportToXlsx(
         widget.locationName,
         widget.sensors,
         _from,
         DateTime(_to.year, _to.month, _to.day, 23, 59, 59),
       );
-      if (mounted) Navigator.pop(context);
+      if (!mounted) return;
+      final messenger = ScaffoldMessenger.of(context);
+      Navigator.pop(context);
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('✓ Збережено в Завантаженнях: $filename'),
+          backgroundColor: AppColors.bgSurface,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
     } catch (error) {
       if (!mounted) return;
       setState(() => _loading = false);
@@ -369,7 +378,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           const Text(
-            'Експорт телеметрії',
+            'Експорт в Excel',
             style: TextStyle(
               color: Colors.white,
               fontSize: 18,
@@ -378,7 +387,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
           ),
           const SizedBox(height: 4),
           const Text(
-            'Оберіть діапазон дат для CSV-файлу',
+            'Оберіть діапазон дат — файл збережеться в Завантаженнях',
             style: TextStyle(color: Colors.white38, fontSize: 13),
           ),
           const SizedBox(height: 20),
@@ -425,7 +434,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
                       ),
                     )
                   : const Text(
-                      'Експортувати',
+                      'Зберегти .xlsx',
                       style: TextStyle(
                         color: Colors.white,
                         fontSize: 16,

--- a/lib/src/services/export_service.dart
+++ b/lib/src/services/export_service.dart
@@ -1,26 +1,36 @@
 import 'dart:developer';
 import 'dart:io';
 
-import 'package:csv/csv.dart';
+import 'package:excel/excel.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:test1/data/repositories/export_repository.dart';
 
 class ExportService {
   final _repo = ExportRepository();
 
-  Future<void> exportToCsv(
+  Future<String> exportToXlsx(
     String locationName,
     List<Map<String, dynamic>> sensors,
     DateTime from,
     DateTime to,
   ) async {
-    final rows = <List<dynamic>>[
-      ['Час', 'Тип', 'Значення', 'Одиниця'],
-    ];
+    final workbook = Excel.createExcel();
+    if (workbook.sheets.containsKey('Sheet1')) {
+      workbook.rename('Sheet1', 'Телеметрія');
+    }
+    final sheet = workbook['Телеметрія'];
+
+    sheet.appendRow([
+      TextCellValue('Час'),
+      TextCellValue('Сенсор'),
+      TextCellValue('Тип'),
+      TextCellValue('Значення'),
+      TextCellValue('Одиниця'),
+    ]);
 
     for (final sensor in sensors) {
       final sensorId = sensor['id'] as String;
+      final sensorName = sensor['name'] as String;
       final type = sensor['type'] as String;
       final unit = sensor['unit'] as String;
       final label = _labelFor(type);
@@ -31,27 +41,40 @@ class ExportService {
       for (final r in records) {
         final raw = r['recorded_at'] as String;
         final dt = DateTime.parse(raw).toLocal();
-        final formatted = _fmtDateTime(dt);
         final value = (r['value'] as num).toDouble();
-        rows.add([formatted, label, value.toStringAsFixed(1), unit]);
+        sheet.appendRow([
+          TextCellValue(_fmtDateTime(dt)),
+          TextCellValue(sensorName),
+          TextCellValue(label),
+          DoubleCellValue(value),
+          TextCellValue(unit),
+        ]);
       }
     }
 
-    final csv = const ListToCsvConverter().convert(rows);
-    final dir = await getTemporaryDirectory();
+    final bytes = workbook.encode();
+    if (bytes == null) throw Exception('Не вдалося створити файл');
 
     final dateStr = '${from.year}'
         '${from.month.toString().padLeft(2, '0')}'
         '${from.day.toString().padLeft(2, '0')}';
     final safeName = locationName.replaceAll(RegExp(r'[^\w]'), '_');
-    final file = File('${dir.path}/chipidiezel_${safeName}_$dateStr.csv');
-    await file.writeAsString(csv);
+    final filename = 'chipidiezel_${safeName}_$dateStr.xlsx';
 
-    log('Exporting CSV: ${file.path}', name: 'ExportService');
-    await Share.shareXFiles(
-      [XFile(file.path, mimeType: 'text/csv')],
-      subject: 'Телеметрія: $locationName',
-    );
+    final file = File('${await _downloadsPath()}/$filename');
+    await file.writeAsBytes(bytes);
+
+    log('Exported to: ${file.path}', name: 'ExportService');
+    return filename;
+  }
+
+  Future<String> _downloadsPath() async {
+    if (Platform.isAndroid) {
+      final dir = Directory('/storage/emulated/0/Download');
+      if (dir.existsSync()) return dir.path;
+    }
+    final dir = await getDownloadsDirectory() ?? await getTemporaryDirectory();
+    return dir.path;
   }
 
   String _labelFor(String type) => switch (type) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
@@ -177,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.7"
+  excel:
+    dependency: "direct main"
+    description:
+      name: excel
+      sha256: "1a15327dcad260d5db21d1f6e04f04838109b39a2f6a84ea486ceda36e468780"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.6"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   provider: ^6.1.2
   share_plus: ^10.0.0
   csv: ^6.0.0
+  excel: ^4.0.6
   path_provider: ^2.1.0
   shared_preferences: ^2.3.0
 


### PR DESCRIPTION
- Use excel package to generate .xlsx instead of CSV — native Unicode support fixes Ukrainian text appearing as garbled symbols
- Save directly to /storage/emulated/0/Download/ (falls back to getDownloadsDirectory() or temp if unavailable)
- Add WRITE_EXTERNAL_STORAGE permission with maxSdkVersion=28 for Android < 10
- ExportService.exportToXlsx() returns filename; caller shows SnackBar "✓ Збережено в Завантаженнях: {filename}" after successful export
- Columns: Час, Сенсор, Тип, Значення, Одиниця (sensor name column added)