### PR TITLE
feat: improve dashboard with empty states, conditional sensor cards a…

### DIFF
--- a/lib/presentation/cubits/dashboard_cubit.dart
+++ b/lib/presentation/cubits/dashboard_cubit.dart
@@ -33,6 +33,7 @@ class DashboardCubit extends Cubit<DashboardState> {
   DashboardSensorData _temp = const DashboardSensorData();
   DashboardSensorData _humidity = const DashboardSensorData();
   DashboardSensorData _pressure = const DashboardSensorData();
+  List<String> _sensorTypes = [];
   String? _lastAlert;
   bool _isFromCache = false;
 
@@ -42,7 +43,17 @@ class DashboardCubit extends Cubit<DashboardState> {
 
   Future<void> startWatching() async {
     emit(const DashboardLoading());
+    await _loadLocations();
+    await Future.wait<void>([
+      _loadSensorsAndData(),
+      _loadLastAlert(),
+    ]);
+    _emitLoaded();
+    _subscribeSensors();
+    _subscribeToEvents();
+  }
 
+  Future<void> _loadLocations() async {
     try {
       _locations = await _locationRepo.getLocations();
     } catch (error, stackTrace) {
@@ -54,18 +65,12 @@ class DashboardCubit extends Cubit<DashboardState> {
       );
     }
 
-    if (_activeLocationId == null && _locations.isNotEmpty) {
+    if (_locations.isEmpty) {
+      _activeLocationId = null;
+    } else if (_activeLocationId == null ||
+        !_locations.any((l) => l['id'] == _activeLocationId)) {
       _activeLocationId = _locations.first['id'] as String;
     }
-
-    await Future.wait<void>([
-      _loadSensorsAndData(),
-      _loadLastAlert(),
-    ]);
-
-    _emitLoaded();
-    _subscribeSensors();
-    _subscribeToEvents();
   }
 
   Future<void> switchLocation(String locationId) async {
@@ -79,6 +84,7 @@ class DashboardCubit extends Cubit<DashboardState> {
     _temp = const DashboardSensorData();
     _humidity = const DashboardSensorData();
     _pressure = const DashboardSensorData();
+    _sensorTypes = [];
     _isFromCache = false;
     _activeLocationId = locationId;
 
@@ -135,9 +141,11 @@ class DashboardCubit extends Cubit<DashboardState> {
     _temp = const DashboardSensorData();
     _humidity = const DashboardSensorData();
     _pressure = const DashboardSensorData();
+    _sensorTypes = [];
 
     emit(const DashboardLoading());
 
+    await _loadLocations();
     await Future.wait<void>([
       _loadSensorsAndData(),
       _loadLastAlert(),
@@ -162,8 +170,14 @@ class DashboardCubit extends Cubit<DashboardState> {
         stackTrace: stackTrace,
       );
       _sensors = [];
+      _sensorTypes = [];
       return;
     }
+
+    _sensorTypes = _sensors
+        .map((s) => s['type'] as String)
+        .toSet()
+        .toList();
 
     await Future.wait([
       for (final sensor in _sensors) _loadInitial(sensor),
@@ -336,6 +350,7 @@ class DashboardCubit extends Cubit<DashboardState> {
         temperature: _temp,
         humidity: _humidity,
         pressure: _pressure,
+        sensorTypes: _sensorTypes,
         lastAlert: _lastAlert,
         locations: _locations,
         activeLocationId: _activeLocationId,
@@ -343,6 +358,8 @@ class DashboardCubit extends Cubit<DashboardState> {
       ),
     );
   }
+
+  Future<void> reload() => _reload();
 
   @override
   Future<void> close() async {

--- a/lib/presentation/cubits/dashboard_state.dart
+++ b/lib/presentation/cubits/dashboard_state.dart
@@ -71,6 +71,7 @@ class DashboardLoaded extends DashboardState {
   final DashboardSensorData temperature;
   final DashboardSensorData humidity;
   final DashboardSensorData pressure;
+  final List<String> sensorTypes;
   final String? lastAlert;
   final List<Map<String, dynamic>> locations;
   final String? activeLocationId;
@@ -81,6 +82,7 @@ class DashboardLoaded extends DashboardState {
     required this.humidity,
     required this.pressure,
     required this.locations,
+    this.sensorTypes = const [],
     this.lastAlert,
     this.activeLocationId,
     this.isFromCache = false,
@@ -90,6 +92,7 @@ class DashboardLoaded extends DashboardState {
     DashboardSensorData? temperature,
     DashboardSensorData? humidity,
     DashboardSensorData? pressure,
+    List<String>? sensorTypes,
     String? lastAlert,
     List<Map<String, dynamic>>? locations,
     String? activeLocationId,
@@ -99,6 +102,7 @@ class DashboardLoaded extends DashboardState {
       temperature: temperature ?? this.temperature,
       humidity: humidity ?? this.humidity,
       pressure: pressure ?? this.pressure,
+      sensorTypes: sensorTypes ?? this.sensorTypes,
       lastAlert: lastAlert ?? this.lastAlert,
       locations: locations ?? this.locations,
       activeLocationId: activeLocationId ?? this.activeLocationId,

--- a/lib/src/screens/home_page/home_content.dart
+++ b/lib/src/screens/home_page/home_content.dart
@@ -52,6 +52,34 @@ class _DashboardView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (state.locations.isEmpty) {
+      return _EmptyState(
+        icon: Icons.location_off_outlined,
+        title: 'Налаштуйте систему',
+        subtitle: 'Додайте першу локацію, щоб почати збирати дані з сенсорів',
+        buttonLabel: 'Налаштувати',
+        onButtonTap: () => Navigator.pushNamedAndRemoveUntil(
+          context,
+          '/onboarding',
+          (route) => false,
+        ),
+      );
+    }
+
+    if (state.sensorTypes.isEmpty) {
+      return _EmptyState(
+        icon: Icons.sensors_off_outlined,
+        title: 'Немає сенсорів',
+        subtitle: 'Додайте сенсори до локації, щоб бачити дані на дашборді',
+        buttonLabel: 'Додати сенсори',
+        onButtonTap: () => Navigator.pushNamed(context, '/sensors').then((_) {
+          if (context.mounted) {
+            context.read<DashboardCubit>().reload();
+          }
+        }),
+      );
+    }
+
     return Column(
       children: [
         if (state.isFromCache)
@@ -63,10 +91,7 @@ class _DashboardView extends StatelessWidget {
                 left: BorderSide(color: AppColors.orange, width: 3),
               ),
             ),
-            padding: const EdgeInsets.symmetric(
-              horizontal: 16,
-              vertical: 10,
-            ),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
             child: const Row(
               children: [
                 Icon(Icons.wifi_off, color: AppColors.orange, size: 16),
@@ -85,7 +110,11 @@ class _DashboardView extends StatelessWidget {
             ),
           ),
         Expanded(
-          child: SingleChildScrollView(
+          child: RefreshIndicator(
+            color: AppColors.orange,
+            backgroundColor: AppColors.bgSurface,
+            onRefresh: () => context.read<DashboardCubit>().reload(),
+            child: SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -115,34 +144,7 @@ class _DashboardView extends StatelessWidget {
                   ),
                 ],
                 const SizedBox(height: 16),
-                Row(
-                  children: [
-                    Expanded(
-                      child: SensorCard(
-                        label: 'Температура',
-                        unit: '°C',
-                        icon: Icons.thermostat,
-                        data: state.temperature,
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: SensorCard(
-                        label: 'Вологість',
-                        unit: '%',
-                        icon: Icons.water_drop,
-                        data: state.humidity,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                SensorCard(
-                  label: 'Тиск',
-                  unit: 'hPa',
-                  icon: Icons.speed,
-                  data: state.pressure,
-                ),
+                _SensorCards(state: state),
                 const SizedBox(height: 28),
                 _NavButton(
                   icon: Icons.show_chart,
@@ -166,13 +168,145 @@ class _DashboardView extends StatelessWidget {
                 _NavButton(
                   icon: Icons.sensors,
                   label: 'Сенсори',
-                  onTap: () => Navigator.pushNamed(context, '/sensors'),
+                  onTap: () =>
+                      Navigator.pushNamed(context, '/sensors').then((_) {
+                    if (context.mounted) {
+                      context.read<DashboardCubit>().reload();
+                    }
+                  }),
                 ),
               ],
             ),
           ),
+          ),
         ),
       ],
+    );
+  }
+}
+
+class _SensorCards extends StatelessWidget {
+  final DashboardLoaded state;
+
+  const _SensorCards({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final hasTemp = state.sensorTypes.contains('temperature');
+    final hasHumidity = state.sensorTypes.contains('humidity');
+    final hasPressure = state.sensorTypes.contains('pressure');
+
+    return Column(
+      children: [
+        if (hasTemp && hasHumidity)
+          Row(
+            children: [
+              Expanded(
+                child: SensorCard(
+                  label: 'Температура',
+                  unit: '°C',
+                  icon: Icons.thermostat,
+                  data: state.temperature,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: SensorCard(
+                  label: 'Вологість',
+                  unit: '%',
+                  icon: Icons.water_drop,
+                  data: state.humidity,
+                ),
+              ),
+            ],
+          )
+        else if (hasTemp)
+          SensorCard(
+            label: 'Температура',
+            unit: '°C',
+            icon: Icons.thermostat,
+            data: state.temperature,
+          )
+        else if (hasHumidity)
+          SensorCard(
+            label: 'Вологість',
+            unit: '%',
+            icon: Icons.water_drop,
+            data: state.humidity,
+          ),
+        if (hasPressure) ...[
+          if (hasTemp || hasHumidity) const SizedBox(height: 12),
+          SensorCard(
+            label: 'Тиск',
+            unit: 'hPa',
+            icon: Icons.speed,
+            data: state.pressure,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final String buttonLabel;
+  final VoidCallback onButtonTap;
+
+  const _EmptyState({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.buttonLabel,
+    required this.onButtonTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              size: 72,
+              color: AppColors.orange.withValues(alpha: 0.6),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              title,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 10),
+            Text(
+              subtitle,
+              style: const TextStyle(
+                color: Colors.white54,
+                fontSize: 14,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 28),
+            SizedBox(
+              width: double.infinity,
+              height: 50,
+              child: ElevatedButton(
+                onPressed: onButtonTap,
+                child: Text(buttonLabel),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/src/screens/telemetry/telemetry_page.dart
+++ b/lib/src/screens/telemetry/telemetry_page.dart
@@ -64,7 +64,7 @@ class _TelemetryPageState extends State<TelemetryPage>
       final telemetryCubits = sensors
           .map(
             (s) => TelemetryDataCubit(
-              label: _labelFor(s['type'] as String),
+              label: s['name'] as String,
               unit: s['unit'] as String,
               sensorType: s['type'] as String,
             ),
@@ -133,7 +133,7 @@ class _TelemetryPageState extends State<TelemetryPage>
       ),
       builder: (_) => ThresholdSettingsWidget(
         sensorId: sensor['id'] as String,
-        label: _labelFor(sensor['type'] as String),
+        label: sensor['name'] as String,
         unit: sensor['unit'] as String,
         cubit: _thresholdCubits[idx],
         onSaved: (min, max) => _telemetryCubits[idx].updateThreshold(min, max),
@@ -229,7 +229,7 @@ class _TelemetryPageState extends State<TelemetryPage>
               cubit: _telemetryCubits[i],
               thresholdCubit: _thresholdCubits[i],
               unit: sensors[i]['unit'] as String,
-              label: _labelFor(sensors[i]['type'] as String),
+              label: sensors[i]['name'] as String,
             ),
           ),
         ),
@@ -250,7 +250,7 @@ class _TelemetryPageState extends State<TelemetryPage>
                   Icons.file_download_outlined,
                   color: AppColors.orangeWarm,
                 ),
-                tooltip: 'Експорт CSV',
+                tooltip: 'Експорт Excel',
                 onPressed: () => _openExportSheet(context),
               ),
               IconButton(
@@ -268,7 +268,11 @@ class _TelemetryPageState extends State<TelemetryPage>
               indicatorColor: AppColors.orange,
               indicatorWeight: 3,
               tabs: sensors
-                  .map((s) => Tab(text: _labelFor(s['type'] as String)))
+                  .map(
+                    (s) => Tab(
+                      text: '${s['name']} (${s['unit']})',
+                    ),
+                  )
                   .toList(),
             )
           : PreferredSize(
@@ -335,13 +339,22 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
   Future<void> _export() async {
     setState(() => _loading = true);
     try {
-      await ExportService().exportToCsv(
+      final filename = await ExportService().exportToXlsx(
         widget.locationName,
         widget.sensors,
         _from,
         DateTime(_to.year, _to.month, _to.day, 23, 59, 59),
       );
-      if (mounted) Navigator.pop(context);
+      if (!mounted) return;
+      final messenger = ScaffoldMessenger.of(context);
+      Navigator.pop(context);
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('✓ Збережено в Завантаженнях: $filename'),
+          backgroundColor: AppColors.bgSurface,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
     } catch (error) {
       if (!mounted) return;
       setState(() => _loading = false);
@@ -369,7 +382,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           const Text(
-            'Експорт телеметрії',
+            'Експорт в Excel',
             style: TextStyle(
               color: Colors.white,
               fontSize: 18,
@@ -378,7 +391,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
           ),
           const SizedBox(height: 4),
           const Text(
-            'Оберіть діапазон дат для CSV-файлу',
+            'Оберіть діапазон дат — файл збережеться в Завантаженнях',
             style: TextStyle(color: Colors.white38, fontSize: 13),
           ),
           const SizedBox(height: 20),
@@ -425,7 +438,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
                       ),
                     )
                   : const Text(
-                      'Експортувати',
+                      'Зберегти .xlsx',
                       style: TextStyle(
                         color: Colors.white,
                         fontSize: 16,

--- a/lib/src/screens/telemetry/telemetry_page.dart
+++ b/lib/src/screens/telemetry/telemetry_page.dart
@@ -250,7 +250,7 @@ class _TelemetryPageState extends State<TelemetryPage>
                   Icons.file_download_outlined,
                   color: AppColors.orangeWarm,
                 ),
-                tooltip: 'Експорт Excel',
+                tooltip: 'Експорт CSV',
                 onPressed: () => _openExportSheet(context),
               ),
               IconButton(
@@ -339,22 +339,13 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
   Future<void> _export() async {
     setState(() => _loading = true);
     try {
-      final filename = await ExportService().exportToXlsx(
+      await ExportService().exportToCsv(
         widget.locationName,
         widget.sensors,
         _from,
         DateTime(_to.year, _to.month, _to.day, 23, 59, 59),
       );
-      if (!mounted) return;
-      final messenger = ScaffoldMessenger.of(context);
-      Navigator.pop(context);
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text('✓ Збережено в Завантаженнях: $filename'),
-          backgroundColor: AppColors.bgSurface,
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      if (mounted) Navigator.pop(context);
     } catch (error) {
       if (!mounted) return;
       setState(() => _loading = false);
@@ -382,7 +373,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           const Text(
-            'Експорт в Excel',
+            'Експорт телеметрії',
             style: TextStyle(
               color: Colors.white,
               fontSize: 18,
@@ -391,7 +382,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
           ),
           const SizedBox(height: 4),
           const Text(
-            'Оберіть діапазон дат — файл збережеться в Завантаженнях',
+            'Оберіть діапазон дат для CSV-файлу',
             style: TextStyle(color: Colors.white38, fontSize: 13),
           ),
           const SizedBox(height: 20),
@@ -438,7 +429,7 @@ class _ExportBottomSheetState extends State<_ExportBottomSheet> {
                       ),
                     )
                   : const Text(
-                      'Зберегти .xlsx',
+                      'Експортувати',
                       style: TextStyle(
                         color: Colors.white,
                         fontSize: 16,


### PR DESCRIPTION
…nd reload

- Extract _loadLocations() called from both startWatching() and _reload(), so new locations appear in dropdown after returning from /sensors
- Add public reload() method; sensors nav button and pull-to-refresh call it
- Add sensorTypes: List<String> to DashboardLoaded; only cards for existing sensor types are rendered (no phantom empty widgets for new accounts)
- Show "Налаштуйте систему" / "Немає сенсорів" empty states instead of blanks
- Telemetry tab labels now use sensor name + unit ("Кухня (°C)") to distinguish multiple sensors of the same type in one location