### PR TITLE
fix: Google OAuth deep link, FCM crash on devices without Play Servic…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
     <application
         android:label="test1"
         android:name="${applicationName}"
@@ -24,7 +27,18 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="com.example.test1"
+                    android:host="login-callback"/>
+            </intent-filter>
         </activity>
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,8 +45,14 @@ void main() async {
   }
 
   await Supabase.initialize(url: supabaseUrl, anonKey: supabaseAnonKey);
-  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-  await FCMService.init();
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+    await FCMService.init();
+  } catch (_) {
+    // FCM unavailable on this device — app continues without push notifications
+  }
 
   final connectivity = Connectivity();
 

--- a/lib/src/cubit/auth/auth_cubit.dart
+++ b/lib/src/cubit/auth/auth_cubit.dart
@@ -87,6 +87,7 @@ class AuthCubit extends Cubit<AuthState> {
     try {
       final launched = await supabase.auth.signInWithOAuth(
         supabase_auth.OAuthProvider.google,
+        redirectTo: 'com.example.test1://login-callback',
       );
       if (!launched) {
         emit(AuthError('Не вдалося відкрити вікно авторизації Google.'));


### PR DESCRIPTION
…es, phantom clicks

- Add intent-filter for com.example.test1://login-callback to catch OAuth redirect back from browser after Supabase processes Google token
- Add redirectTo parameter to signInWithOAuth so Supabase knows where to redirect after successful authentication
- Wrap Firebase/FCMService.init() in try-catch so app launches normally on devices without Google Play Services (e.g. some Xiaomi models)
- Disable Impeller (EnableImpeller=false) to fix phantom touch events on Android devices with Vulkan rendering issues
- Add WRITE_EXTERNAL_STORAGE permission with maxSdkVersion=28 for .xlsx export